### PR TITLE
refactor: 引入 LangEngineContext 和 LangEngineConfig，优化回调管理器和缓存的获取逻辑

### DIFF
--- a/ali-langengine-core/src/main/java/com/alibaba/langengine/core/chain/Chain.java
+++ b/ali-langengine-core/src/main/java/com/alibaba/langengine/core/chain/Chain.java
@@ -25,6 +25,7 @@ import com.alibaba.langengine.core.callback.BaseCallbackManager;
 import com.alibaba.langengine.core.callback.CallbackManager;
 import com.alibaba.langengine.core.callback.ExecutionContext;
 import com.alibaba.langengine.core.runnables.RunnableStreamCallback;
+import com.alibaba.langengine.core.config.LangEngineContext;
 import com.alibaba.langengine.core.config.LangEngineConfiguration;
 import com.alibaba.langengine.core.memory.BaseMemory;
 import com.alibaba.langengine.core.languagemodel.BaseLanguageModel;
@@ -75,9 +76,24 @@ public abstract class Chain extends Runnable<RunnableInput, RunnableOutput> {
     @JsonIgnore
     private BaseCallbackManager callbackManager;
 
+    @JsonIgnore
+    private LangEngineContext context;
+
+    public LangEngineContext getContext() {
+        return context;
+    }
+
+    public void setContext(LangEngineContext context) {
+        this.context = context;
+    }
+
     public BaseCallbackManager getCallbackManager() {
         if(callbackManager == null) {
-            callbackManager = LangEngineConfiguration.CALLBACK_MANAGER;
+            if (context != null && context.getConfig() != null && context.getConfig().getCallbackManager() != null) {
+                callbackManager = context.getConfig().getCallbackManager();
+            } else {
+                callbackManager = LangEngineConfiguration.CALLBACK_MANAGER;
+            }
         }
         return callbackManager;
     }

--- a/ali-langengine-core/src/main/java/com/alibaba/langengine/core/config/LangEngineConfig.java
+++ b/ali-langengine-core/src/main/java/com/alibaba/langengine/core/config/LangEngineConfig.java
@@ -1,0 +1,74 @@
+package com.alibaba.langengine.core.config;
+
+import com.alibaba.langengine.core.caches.BaseCache;
+import com.alibaba.langengine.core.callback.BaseCallbackManager;
+import com.alibaba.langengine.core.util.NullAwareBeanUtilsBean;
+
+/**
+ * 不可变的引擎配置，支持通过构建器注入依赖。
+ */
+public final class LangEngineConfig {
+
+	private final BaseCache cache;
+	private final BaseCallbackManager callbackManager;
+	private final NullAwareBeanUtilsBean beanUtils;
+	private final Integer retrievalQaRecommendCount;
+
+	private LangEngineConfig(Builder builder) {
+		this.cache = builder.cache;
+		this.callbackManager = builder.callbackManager;
+		this.beanUtils = builder.beanUtils;
+		this.retrievalQaRecommendCount = builder.retrievalQaRecommendCount;
+	}
+
+	public BaseCache getCache() {
+		return cache;
+	}
+
+	public BaseCallbackManager getCallbackManager() {
+		return callbackManager;
+	}
+
+	public NullAwareBeanUtilsBean getBeanUtils() {
+		return beanUtils;
+	}
+
+	public Integer getRetrievalQaRecommendCount() {
+		return retrievalQaRecommendCount;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private BaseCache cache;
+		private BaseCallbackManager callbackManager;
+		private NullAwareBeanUtilsBean beanUtils;
+		private Integer retrievalQaRecommendCount;
+
+		public Builder cache(BaseCache cache) {
+			this.cache = cache;
+			return this;
+		}
+
+		public Builder callbackManager(BaseCallbackManager callbackManager) {
+			this.callbackManager = callbackManager;
+			return this;
+		}
+
+		public Builder beanUtils(NullAwareBeanUtilsBean beanUtils) {
+			this.beanUtils = beanUtils;
+			return this;
+		}
+
+		public Builder retrievalQaRecommendCount(Integer count) {
+			this.retrievalQaRecommendCount = count;
+			return this;
+		}
+
+		public LangEngineConfig build() {
+			return new LangEngineConfig(this);
+		}
+	}
+}

--- a/ali-langengine-core/src/main/java/com/alibaba/langengine/core/config/LangEngineContext.java
+++ b/ali-langengine-core/src/main/java/com/alibaba/langengine/core/config/LangEngineContext.java
@@ -1,0 +1,50 @@
+package com.alibaba.langengine.core.config;
+
+import com.alibaba.langengine.core.caches.BaseCache;
+import com.alibaba.langengine.core.callback.BaseCallbackManager;
+import com.alibaba.langengine.core.callback.CallbackManager;
+import com.alibaba.langengine.core.util.NullAwareBeanUtilsBean;
+import com.alibaba.langengine.core.util.WorkPropertiesUtils;
+
+/**
+ * 可传递的上下文，封装配置对象。提供向后兼容的默认构造。
+ */
+public class LangEngineContext {
+
+	private final LangEngineConfig config;
+
+	public LangEngineContext(LangEngineConfig config) {
+		this.config = config;
+	}
+
+	public LangEngineConfig getConfig() {
+		return config;
+	}
+
+	/**
+	 * 向后兼容的默认上下文：尽量从旧的静态配置桥接，避免一次性大改。
+	 */
+	public static LangEngineContext defaultContext() {
+		BaseCache cache = LangEngineConfiguration.CurrentCache;
+		BaseCallbackManager cm = LangEngineConfiguration.CALLBACK_MANAGER != null
+				? LangEngineConfiguration.CALLBACK_MANAGER
+				: new CallbackManager();
+		NullAwareBeanUtilsBean beanUtils = LangEngineConfiguration.NULL_AWARE_BEAN_UTILS_BEAN != null
+				? LangEngineConfiguration.NULL_AWARE_BEAN_UTILS_BEAN
+				: new NullAwareBeanUtilsBean();
+		Integer recommend = null;
+		try {
+			recommend = Integer.parseInt(
+					WorkPropertiesUtils.get("retrieval_qa_recommend_count", "2"));
+		} catch (Throwable ignore) {
+		}
+
+		LangEngineConfig cfg = LangEngineConfig.builder()
+				.cache(cache)
+				.callbackManager(cm)
+				.beanUtils(beanUtils)
+				.retrievalQaRecommendCount(recommend)
+				.build();
+		return new LangEngineContext(cfg);
+	}
+}

--- a/ali-langengine-core/src/main/java/com/alibaba/langengine/core/indexes/BaseRetriever.java
+++ b/ali-langengine-core/src/main/java/com/alibaba/langengine/core/indexes/BaseRetriever.java
@@ -18,6 +18,7 @@ package com.alibaba.langengine.core.indexes;
 import com.alibaba.langengine.core.callback.BaseCallbackManager;
 import com.alibaba.langengine.core.callback.CallbackManager;
 import com.alibaba.langengine.core.callback.ExecutionContext;
+import com.alibaba.langengine.core.config.LangEngineContext;
 import com.alibaba.langengine.core.runnables.RunnableStreamCallback;
 import com.alibaba.langengine.core.runnables.*;
 import com.alibaba.langengine.core.runnables.Runnable;
@@ -45,15 +46,30 @@ public abstract class BaseRetriever extends Runnable<RunnableInput, RunnableOutp
     /**
      * 回调管理器
      */
-    @JsonIgnore
-    private BaseCallbackManager callbackManager;
+	@JsonIgnore
+	private BaseCallbackManager callbackManager;
 
-    public BaseCallbackManager getCallbackManager() {
-        if(callbackManager == null) {
-            callbackManager = LangEngineConfiguration.CALLBACK_MANAGER;
-        }
-        return callbackManager;
-    }
+	@JsonIgnore
+	private LangEngineContext context;
+
+	public LangEngineContext getContext() {
+		return context;
+	}
+
+	public void setContext(LangEngineContext context) {
+		this.context = context;
+	}
+
+	public BaseCallbackManager getCallbackManager() {
+		if(callbackManager == null) {
+			if (context != null && context.getConfig() != null && context.getConfig().getCallbackManager() != null) {
+				callbackManager = context.getConfig().getCallbackManager();
+			} else {
+				callbackManager = LangEngineConfiguration.CALLBACK_MANAGER;
+			}
+		}
+		return callbackManager;
+	}
 
     public void setCallbackManager(BaseCallbackManager callbackManager) {
         if (callbackManager != null && callbackManager.getRunManager() != null) {

--- a/ali-langengine-core/src/main/java/com/alibaba/langengine/core/languagemodel/BaseLanguageModel.java
+++ b/ali-langengine-core/src/main/java/com/alibaba/langengine/core/languagemodel/BaseLanguageModel.java
@@ -25,6 +25,7 @@ import com.alibaba.langengine.core.agent.AgentOutputParser;
 import com.alibaba.langengine.core.callback.BaseCallbackManager;
 import com.alibaba.langengine.core.callback.CallbackManager;
 import com.alibaba.langengine.core.callback.ExecutionContext;
+import com.alibaba.langengine.core.config.LangEngineContext;
 import com.alibaba.langengine.core.runnables.RunnableStreamCallback;
 import com.alibaba.langengine.core.memory.BaseMemory;
 import com.alibaba.langengine.core.messages.BaseMessage;
@@ -43,7 +44,7 @@ import com.alibaba.langengine.core.runnables.RunnableOutput;
 import com.alibaba.langengine.core.runnables.RunnableStringVar;
 import com.alibaba.langengine.core.tokenizers.GPT2Tokenizer;
 import com.alibaba.langengine.core.util.JacksonUtils;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Data;
 import org.apache.commons.collections.CollectionUtils;
@@ -123,6 +124,17 @@ public abstract class BaseLanguageModel<T> extends Runnable<RunnableInput, Runna
      * 如果您希望对于某一类问题，Function Calling 能够强制调用某个工具，可以设定tool_choice参数为{"type": "function", "function": {"name": "the_function_to_call"}}，其中the_function_to_call是您指定的工具函数名称。
      */
     private Object toolChoice = "auto";
+
+	@JsonIgnore
+	private LangEngineContext context;
+
+	public LangEngineContext getContext() {
+		return context;
+	}
+
+	public void setContext(LangEngineContext context) {
+		this.context = context;
+	}
 
 
     /**

--- a/ali-langengine-core/src/main/java/com/alibaba/langengine/core/tool/BaseTool.java
+++ b/ali-langengine-core/src/main/java/com/alibaba/langengine/core/tool/BaseTool.java
@@ -19,6 +19,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.langengine.core.callback.BaseCallbackManager;
 import com.alibaba.langengine.core.callback.CallbackManager;
 import com.alibaba.langengine.core.callback.ExecutionContext;
+import com.alibaba.langengine.core.config.LangEngineContext;
 import com.alibaba.langengine.core.model.fastchat.completion.chat.FunctionDefinition;
 import com.alibaba.langengine.core.model.fastchat.completion.chat.FunctionParameter;
 import com.alibaba.langengine.core.runnables.RunnableStreamCallback;
@@ -29,6 +30,7 @@ import com.alibaba.langengine.core.runnables.RunnableConfig;
 import com.alibaba.langengine.core.runnables.RunnableHashMap;
 import com.alibaba.langengine.core.runnables.RunnableOutput;
 import com.alibaba.langengine.core.util.JacksonUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Data;
@@ -56,14 +58,29 @@ public abstract class BaseTool extends Runnable<Object, RunnableOutput> {
     /**
      * callback manager
      */
-    private BaseCallbackManager callbackManager;
+	private BaseCallbackManager callbackManager;
 
-    public BaseCallbackManager getCallbackManager() {
-        if(callbackManager == null) {
-            callbackManager = LangEngineConfiguration.CALLBACK_MANAGER;
-        }
-        return callbackManager;
-    }
+	@JsonIgnore
+	private LangEngineContext context;
+
+	public LangEngineContext getContext() {
+		return context;
+	}
+
+	public void setContext(LangEngineContext context) {
+		this.context = context;
+	}
+
+	public BaseCallbackManager getCallbackManager() {
+		if(callbackManager == null) {
+			if (context != null && context.getConfig() != null && context.getConfig().getCallbackManager() != null) {
+				callbackManager = context.getConfig().getCallbackManager();
+			} else {
+				callbackManager = LangEngineConfiguration.CALLBACK_MANAGER;
+			}
+		}
+		return callbackManager;
+	}
 
     /**
      * 明确传达其用途的工具的唯一名称，英文key


### PR DESCRIPTION
config 新增2类；
Chain/BaseTool/BaseRetriever 注入上下文并优先用其回调；
BaseLanguageModel 增加上下文字段；
BaseLLM/BaseChatModel 缓存优先取上下文

这套改动只涉及“配置与依赖注入”，其它行为保持不变，且对旧的全局静态配置完全兼容