### PR TITLE
feat: 新增 ChainResult、TokenUsage 和 StandardKeys 类，优化链式输出和令牌用量统计

### DIFF
--- a/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/schema/ChainResult.java
+++ b/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/schema/ChainResult.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2024 AIDC-AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.agentic.core.schema;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+/**
+ * 标准链式输出，替代 Map + 魔法 key 的弱类型返回。
+ */
+@Data
+@NoArgsConstructor
+@Accessors(chain = true)
+public class ChainResult {
+
+    /**
+     * 主文本输出。
+     */
+    private String text;
+
+    /**
+     * 可选：会话标识，便于多轮场景续写。
+     */
+    private String sessionId;
+
+    /**
+     * 令牌用量等统计信息。
+     */
+    private TokenUsage tokens;
+
+    /**
+     * 其他扩展信息（结构化元数据）。
+     */
+    private Map<String, Object> metadata;
+}
+

--- a/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/schema/StandardKeys.java
+++ b/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/schema/StandardKeys.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2024 AIDC-AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.agentic.core.schema;
+
+/**
+ * 标准输出键名常量，避免魔法字符串。
+ */
+public final class StandardKeys {
+    private StandardKeys() {}
+
+    public static final String TEXT = "text";
+    public static final String SESSION_ID = "sessionId";
+    public static final String TOKENS = "tokens";
+    public static final String METADATA = "metadata";
+}
+

--- a/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/schema/TokenUsage.java
+++ b/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/schema/TokenUsage.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2024 AIDC-AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.agentic.core.schema;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+/**
+ * 令牌用量统计。
+ */
+@Data
+@NoArgsConstructor
+@Accessors(chain = true)
+public class TokenUsage {
+    private Integer promptTokens;
+    private Integer completionTokens;
+    private Integer totalTokens;
+}
+

--- a/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/tools/DashScopeTools.java
+++ b/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/tools/DashScopeTools.java
@@ -23,7 +23,6 @@ import com.alibaba.dashscope.app.ApplicationResult;
 import com.alibaba.dashscope.exception.ApiException;
 import com.alibaba.dashscope.exception.InputRequiredException;
 import com.alibaba.dashscope.exception.NoApiKeyException;
-import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.Schema;
@@ -36,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
+import com.alibaba.agentic.core.schema.StandardKeys;
 
 @Component
 @Data
@@ -62,8 +62,8 @@ public class DashScopeTools implements FunctionTool {
                 Application application = new Application();
                 ApplicationResult result = application.call(applicationParam);
                 Map<String, Object> output = new HashMap<>();
-                output.put("text", result.getOutput().getText());
-                output.put("sessionId", result.getOutput().getSessionId());
+                output.put(StandardKeys.TEXT, result.getOutput().getText());
+                output.put(StandardKeys.SESSION_ID, result.getOutput().getSessionId());
                 emitter.onNext(output);
                 emitter.onComplete();
             } catch (ApiException | NoApiKeyException | InputRequiredException e) {
@@ -109,12 +109,12 @@ public class DashScopeTools implements FunctionTool {
                         Schema.builder()
                                 .type("OBJECT")
                                 .properties(Map.of(
-                                        "text", Schema.builder()
+                                        StandardKeys.TEXT, Schema.builder()
                                                 .type("STRING").description("回复内容").build(),
-                                        "sessionId", Schema.builder()
+                                        StandardKeys.SESSION_ID, Schema.builder()
                                                 .type("STRING").description("本轮返回的会话ID").build()
                                 ))
-                                .required(java.util.List.of("text", "sessionId"))
+                                .required(java.util.List.of(StandardKeys.TEXT, StandardKeys.SESSION_ID))
                                 .build()
                 )
                 .build();


### PR DESCRIPTION
强类型 I/O 契约
- 定义 `InputSchema`/`OutputSchema`（POJO/record）替代 `Map` 与魔法 key；或使用 `TypedMap` + 常量键名。
- 为标准输出定义统一返回类型（如 `ChainResult{text, tokens, metadata}`），避免 `null` 与魔法 `"text"`。