### PR TITLE
feat: openai support base url arg

### DIFF
--- a/ali-langengine-community/ali-langengine-openai/src/main/java/com/alibaba/langengine/openai/model/ChatModelOpenAI.java
+++ b/ali-langengine-community/ali-langengine-openai/src/main/java/com/alibaba/langengine/openai/model/ChatModelOpenAI.java
@@ -73,6 +73,45 @@ public class ChatModelOpenAI extends BaseChatModel<ChatCompletionRequest> {
     }
 
     /**
+     * Support custom base URL
+     */
+    public ChatModelOpenAI(String apiKey, String baseUrl) {
+        this(apiKey, baseUrl, Long.parseLong(OPENAI_AI_TIMEOUT));
+    }
+
+    /**
+     * Support custom base URL with timeout
+     */
+    public ChatModelOpenAI(String apiKey, String baseUrl, Long timeout) {
+        setModel(OpenAIModelConstants.GPT_35_TURBO);
+        setTemperature(0.7d);
+        setMaxTokens(256);
+        setTemperature(1.0d);
+        setFrequencyPenalty(0.0d);
+        setPresencePenalty(0.0d);
+        
+        String serverUrl = !StringUtils.isEmpty(baseUrl) ? baseUrl : 
+                          (!StringUtils.isEmpty(OPENAI_SERVER_URL) ? OPENAI_SERVER_URL : DEFAULT_BASE_URL);
+        service = new FastChatService(serverUrl, Duration.ofSeconds(timeout), true, apiKey);
+    }
+
+    /**
+     * Complete parameter constructor
+     */
+    public ChatModelOpenAI(String apiKey, String baseUrl, Long timeout, String model) {
+        setModel(!StringUtils.isEmpty(model) ? model : OpenAIModelConstants.GPT_35_TURBO);
+        setTemperature(0.7d);
+        setMaxTokens(256);
+        setTemperature(1.0d);
+        setFrequencyPenalty(0.0d);
+        setPresencePenalty(0.0d);
+        
+        String serverUrl = !StringUtils.isEmpty(baseUrl) ? baseUrl : 
+                          (!StringUtils.isEmpty(OPENAI_SERVER_URL) ? OPENAI_SERVER_URL : DEFAULT_BASE_URL);
+        service = new FastChatService(serverUrl, Duration.ofSeconds(timeout), true, apiKey);
+    }
+
+    /**
      * 为每个提示生成多少完成
      */
     private int n = 1;


### PR DESCRIPTION
## PR Title
feat: Add custom baseUrl constructor support for ChatModelOpenAI

## PR Description

### 🚀 Enhancement

Added custom baseUrl constructor support to [ChatModelOpenAI](cci:2://file:///Users/zxj/Agentic-ADK/ali-langengine-community/ali-langengine-openai/src/main/java/com/alibaba/langengine/openai/model/ChatModelOpenAI.java:47:0-305:1) class to improve flexibility and compatibility for OpenAI client configurations.

### 📝 Changes Made

**New Constructors:**
1. [ChatModelOpenAI(String apiKey, String baseUrl)](cci:2://file:///Users/zxj/Agentic-ADK/ali-langengine-community/ali-langengine-openai/src/main/java/com/alibaba/langengine/openai/model/ChatModelOpenAI.java:47:0-305:1) - Support custom base URL
2. [ChatModelOpenAI(String apiKey, String baseUrl, Long timeout)](cci:2://file:///Users/zxj/Agentic-ADK/ali-langengine-community/ali-langengine-openai/src/main/java/com/alibaba/langengine/openai/model/ChatModelOpenAI.java:47:0-305:1) - Support custom base URL with timeout
3. [ChatModelOpenAI(String apiKey, String baseUrl, Long timeout, String model)](cci:2://file:///Users/zxj/Agentic-ADK/ali-langengine-community/ali-langengine-openai/src/main/java/com/alibaba/langengine/openai/model/ChatModelOpenAI.java:47:0-305:1) - Complete parameter constructor

**URL Priority Logic:**
- First: Use provided `baseUrl` parameter
- Second: Fall back to `OPENAI_SERVER_URL` configuration
- Third: Use `DEFAULT_BASE_URL` as final fallback

### 🎯 Use Cases

- Connect to OpenAI-compatible third-party API services
- Support enterprise internal OpenAI proxy services
- Support different regional OpenAI API endpoints
- Provide more flexible service configuration options

### ✅ Compatibility

- All existing constructors remain unchanged
- Backward compatible, no impact on existing code
- Follows existing parameter setting patterns