### PR TITLE
feat(python): add Google embedding provider and tests

### DIFF
--- a/ali-agentic-adk-python/pyproject.toml
+++ b/ali-agentic-adk-python/pyproject.toml
@@ -18,6 +18,7 @@ authors = [
 
 dependencies = [
     "google-adk",
+    "google-generativeai",
     "aiohttp",
     "dashscope",
     "openai",
@@ -32,7 +33,6 @@ dependencies = [
 [tool.hatch.build]
 include = ["src/*"]
 exclude = ["examples/**", "tests/**", "docs/**"]
-
 
 
 

--- a/ali-agentic-adk-python/requirements.txt
+++ b/ali-agentic-adk-python/requirements.txt
@@ -1,4 +1,5 @@
 google-adk
+google-generativeai
 
 aiohttp
 dashscope

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/__init__.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/__init__.py
@@ -21,8 +21,10 @@
 
 from .basic_embedding import BasicEmbedding
 from .openai_embedding import OpenAIEmbedding
+from .google_embedding import GoogleEmbedding
 
 __all__ = [
     "BasicEmbedding",
     "OpenAIEmbedding",
+    "GoogleEmbedding",
 ]

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/google_embedding.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/google_embedding.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Google embedding provider implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Sequence
+
+try:  # pragma: no cover - import guard
+    import google.generativeai as genai
+except ImportError as import_error:  # pragma: no cover - handled at runtime
+    genai = None  # type: ignore[assignment]
+    _IMPORT_ERROR = import_error
+else:
+    _IMPORT_ERROR = None
+
+from ..common.exceptions import EmbeddingProviderError
+from .basic_embedding import BasicEmbedding
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleEmbedding(BasicEmbedding):
+    """Embedding provider backed by Google Generative AI."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "models/embedding-001",
+        *,
+        client_options: Dict[str, Any] | None = None,
+        request_options: Dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(model=model)
+        if genai is None:  # pragma: no cover - depends on optional dependency
+            raise ImportError(
+                "google-generativeai is required to use GoogleEmbedding"
+            ) from _IMPORT_ERROR
+        configuration: Dict[str, Any] = {"api_key": api_key}
+        if client_options:
+            configuration.update(client_options)
+
+        # google.generativeai keeps configuration at module scope.
+        genai.configure(**configuration)
+        self._request_options = request_options.copy() if request_options else {}
+
+    def embed_documents(self, texts: Sequence[str]) -> List[List[float]]:
+        normalized_inputs = self._normalize_inputs(texts)
+        if not normalized_inputs:
+            return []
+
+        embeddings: List[List[float]] = []
+        for text in normalized_inputs:
+            payload: Dict[str, Any] = {"model": self.model, "content": text}
+            payload.update(self._request_options)
+
+            try:
+                response = genai.embed_content(**payload)
+            except Exception as exc:  # pragma: no cover - propagated for callers
+                message = "Failed to retrieve embeddings from Google provider"
+                logger.exception(message)
+                raise EmbeddingProviderError(message, original_exception=exc) from exc
+
+            vector = self._extract_embedding(response)
+            if not vector:
+                raise EmbeddingProviderError("Google response did not contain embedding vectors")
+            embeddings.append(list(vector))
+
+        return embeddings
+
+    @staticmethod
+    def _extract_embedding(response: Any) -> Iterable[float] | None:
+        if response is None:
+            return None
+        if hasattr(response, "embedding"):
+            embedding = getattr(response, "embedding")
+            if embedding is not None:
+                return embedding
+        if isinstance(response, dict):
+            embedding = response.get("embedding")
+            if embedding is not None:
+                return embedding
+        return None
+
+
+__all__ = ["GoogleEmbedding"]

--- a/ali-agentic-adk-python/tests/test_google_embedding.py
+++ b/ali-agentic-adk-python/tests/test_google_embedding.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+import unittest
+from unittest.mock import call, patch
+
+from ali_agentic_adk_python.core.common.exceptions import EmbeddingProviderError
+from ali_agentic_adk_python.core.embedding.google_embedding import GoogleEmbedding
+
+
+class GoogleEmbeddingTestCase(unittest.TestCase):
+    @patch("ali_agentic_adk_python.core.embedding.google_embedding.genai")
+    def test_embed_documents_returns_vectors(self, genai_mock):
+        genai_mock.embed_content.side_effect = [
+            {"embedding": [0.1, 0.2]},
+            {"embedding": [0.3, 0.4]},
+        ]
+
+        embedding = GoogleEmbedding(api_key="key", model="test-model")
+        vectors = embedding.embed_documents(["a", "b"])
+
+        self.assertEqual(vectors, [[0.1, 0.2], [0.3, 0.4]])
+        genai_mock.configure.assert_called_once_with(api_key="key")
+        genai_mock.embed_content.assert_has_calls(
+            [
+                call(model="test-model", content="a"),
+                call(model="test-model", content="b"),
+            ]
+        )
+
+    @patch("ali_agentic_adk_python.core.embedding.google_embedding.genai")
+    def test_request_options_are_forwarded(self, genai_mock):
+        genai_mock.embed_content.return_value = {"embedding": [0.5, 0.6]}
+
+        embedding = GoogleEmbedding(
+            api_key="key",
+            model="test-model",
+            request_options={"task_type": "semantic_similarity"},
+        )
+        embedding.embed_documents(["hello"])
+
+        genai_mock.embed_content.assert_called_once_with(
+            model="test-model",
+            content="hello",
+            task_type="semantic_similarity",
+        )
+
+    @patch("ali_agentic_adk_python.core.embedding.google_embedding.genai")
+    def test_missing_vectors_raise(self, genai_mock):
+        genai_mock.embed_content.return_value = {}
+
+        embedding = GoogleEmbedding(api_key="key", model="test-model")
+
+        with self.assertRaises(EmbeddingProviderError):
+            embedding.embed_documents(["text"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Google Generative AI embedding provider that mirrors the existing OpenAI integration
- export the provider and declare the google-generativeai dependency for downstream users
- cover the new embedding flow with mocked unit tests

## Testing
- conda run -n adk-embed env PYTHONPATH=ali-agentic-adk-python/src python -m pytest ali-agentic-adk-python/tests/test_google_embedding.py ali-agentic-adk-python/tests/test_openai_embedding.py

<img width="1065" height="272" alt="image" src="https://github.com/user-attachments/assets/e38bf9c1-c517-4f21-89e7-ff31099b6c44" />

Fixes #25
