### PR TITLE
feat(gitignore): add Python-specific ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ maven-metadata-*.xml
 *.jar
 *.war
 *.ear
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.env


### PR DESCRIPTION
## Summary
1. Add the necessary gitignore rules for a Python project, including cache folders and compiled bytecode files.

## Changes
1.  Add the directory `__pycache__ `to the .gitignore file for ignoring.
2. Add *.py[cod] and *.pyo compiled files to be ignored
3.Add .env environment variable file to ignore
