### PR TITLE
feat(python): add Bailian embedding provider

### DIFF
--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/bailian_embedding.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/bailian_embedding.py
@@ -19,12 +19,40 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-from .basic_embedding import BasicEmbedding
-from .openai_embedding import OpenAIEmbedding
-from .bailian_embedding import BailianEmbedding
+"""Bailian embedding provider built on any's OpenAI-compatible API."""
 
-__all__ = [
-    "BasicEmbedding",
-    "OpenAIEmbedding",
-    "BailianEmbedding",
-]
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .openai_embedding import OpenAIEmbedding
+
+_DEFAULT_BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+class BailianEmbedding(OpenAIEmbedding):
+    """Embedding provider that targets Alibaba Cloud Bailian platform."""
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "text-embedding-v1",
+        *,
+        base_url: str | None = None,
+        dimensions: int | None = None,
+        user: str | None = None,
+        client_options: Dict[str, Any] | None = None,
+        request_options: Dict[str, Any] | None = None,
+    ) -> None:
+        resolved_base_url = base_url or _DEFAULT_BAILIAN_BASE_URL
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            base_url=resolved_base_url,
+            dimensions=dimensions,
+            user=user,
+            client_options=client_options,
+            request_options=request_options,
+        )
+
+
+__all__ = ["BailianEmbedding"]

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/dashscope_embedding.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/dashscope_embedding.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+"""DashScope embedding provider implementation."""
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import Any, Dict, List, Sequence
+
+try: 
+    from dashscope import TextEmbedding
+except ImportError as import_error:  
+    TextEmbedding = None 
+    _IMPORT_ERROR = import_error
+else:
+    _IMPORT_ERROR = None
+
+from ..common.exceptions import EmbeddingProviderError
+from .basic_embedding import BasicEmbedding
+
+logger = logging.getLogger(__name__)
+
+
+class DashScopeEmbedding(BasicEmbedding):
+    """Embedding provider backed by Alibaba DashScope API."""
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "text-embedding-v4",
+        *,
+        workspace: str | None = None,
+        request_options: Dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(model=model)
+        if TextEmbedding is None:  
+            raise ImportError("dashscope is required to use DashScopeEmbedding") from _IMPORT_ERROR
+
+        self._api_key = api_key
+        self._workspace = workspace
+        self._request_options = request_options.copy() if request_options else {}
+
+    def embed_documents(self, texts: Sequence[str]) -> List[List[float]]:
+        normalized_inputs = self._normalize_inputs(texts)
+        if not normalized_inputs:
+            return []
+
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "input": normalized_inputs,
+            "api_key": self._api_key,
+        }
+        if self._workspace is not None:
+            payload["workspace"] = self._workspace
+        payload.update(self._request_options)
+
+        try:
+            response = TextEmbedding.call(**payload)
+        except Exception as exc:  
+            message = "Failed to retrieve embeddings from DashScope provider"
+            logger.exception(message)
+            raise EmbeddingProviderError(message, original_exception=exc) from exc
+
+        status_code = getattr(response, "status_code", None)
+        if status_code != HTTPStatus.OK:
+            message = (
+                "DashScope provider returned unsuccessful status code "
+                f"{status_code!r}"
+            )
+            logger.error(message)
+            raise EmbeddingProviderError(message)
+
+        output = getattr(response, "output", None) or {}
+        embeddings_payload = output.get("embeddings") if isinstance(output, dict) else None
+        if not embeddings_payload:
+            raise EmbeddingProviderError("DashScope response did not contain embedding vectors")
+
+        vectors_by_index: Dict[int, List[float]] = {}
+        for idx, item in enumerate(embeddings_payload):
+            if not isinstance(item, dict):
+                raise EmbeddingProviderError("DashScope embedding item is not a mapping")
+            vector = item.get("embedding")
+            if not vector:
+                raise EmbeddingProviderError("DashScope response did not contain embedding vectors")
+            index = item.get("text_index", idx)
+            vectors_by_index[int(index)] = list(vector)
+
+        embeddings: List[List[float]] = []
+        for index in range(len(normalized_inputs)):
+            vector = vectors_by_index.get(index)
+            if vector is None:
+                raise EmbeddingProviderError(
+                    f"DashScope response missing embedding for input index {index}"
+                )
+            embeddings.append(vector)
+
+        return embeddings
+
+
+__all__ = ["DashScopeEmbedding"]

--- a/ali-agentic-adk-python/tests/test_bailian_embedding.py
+++ b/ali-agentic-adk-python/tests/test_bailian_embedding.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ali_agentic_adk_python.core.common.exceptions import EmbeddingProviderError
+from ali_agentic_adk_python.core.embedding.bailian_embedding import BailianEmbedding
+
+
+class BailianEmbeddingTestCase(unittest.TestCase):
+    @patch("ali_agentic_adk_python.core.embedding.openai_embedding.OpenAI")
+    def test_embed_documents_returns_vectors(self, openai_cls):
+        client_mock = MagicMock()
+        openai_cls.return_value = client_mock
+        client_mock.embeddings.create.return_value = MagicMock(
+            data=[
+                MagicMock(embedding=[0.1, 0.2]),
+                MagicMock(embedding=[0.3, 0.4]),
+            ]
+        )
+
+        embedding = BailianEmbedding(api_key="key", model="test-model")
+        vectors = embedding.embed_documents(["a", "b"])
+
+        self.assertEqual(vectors, [[0.1, 0.2], [0.3, 0.4]])
+        openai_cls.assert_called_once()
+        _, kwargs = openai_cls.call_args
+        self.assertEqual(kwargs.get("api_key"), "key")
+        self.assertEqual(
+            kwargs.get("base_url"), "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        )
+        client_mock.embeddings.create.assert_called_once_with(
+            model="test-model",
+            input=["a", "b"],
+        )
+
+    @patch("ali_agentic_adk_python.core.embedding.openai_embedding.OpenAI")
+    def test_request_options_are_forwarded(self, openai_cls):
+        client_mock = MagicMock()
+        openai_cls.return_value = client_mock
+        client_mock.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.5, 0.6])]
+        )
+
+        embedding = BailianEmbedding(
+            api_key="key",
+            model="test-model",
+            dimensions=512,
+            user="alice",
+            request_options={"encoding_format": "float"},
+        )
+        embedding.embed_documents(["hello"])
+
+        client_mock.embeddings.create.assert_called_once_with(
+            model="test-model",
+            input=["hello"],
+            dimensions=512,
+            user="alice",
+            encoding_format="float",
+        )
+
+    @patch("ali_agentic_adk_python.core.embedding.openai_embedding.OpenAI")
+    def test_custom_base_url_is_respected(self, openai_cls):
+        client_mock = MagicMock()
+        openai_cls.return_value = client_mock
+        client_mock.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.9, 1.0])]
+        )
+
+        custom_url = "https://example.com/v1"
+        embedding = BailianEmbedding(api_key="key", model="test-model", base_url=custom_url)
+        embedding.embed_documents(["ping"])
+
+        _, kwargs = openai_cls.call_args
+        self.assertEqual(kwargs.get("base_url"), custom_url)
+
+    @patch("ali_agentic_adk_python.core.embedding.openai_embedding.OpenAI")
+    def test_missing_vectors_raise(self, openai_cls):
+        client_mock = MagicMock()
+        openai_cls.return_value = client_mock
+        client_mock.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[])])
+
+        embedding = BailianEmbedding(api_key="key", model="test-model")
+
+        with self.assertRaises(EmbeddingProviderError):
+            embedding.embed_documents(["text"])
+
+    @patch("ali_agentic_adk_python.core.embedding.openai_embedding.OpenAI")
+    def test_embed_query_returns_single_vector(self, openai_cls):
+        client_mock = MagicMock()
+        openai_cls.return_value = client_mock
+        client_mock.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.7, 0.8, 0.9])]
+        )
+
+        embedding = BailianEmbedding(api_key="key", model="test-model")
+        vector = embedding.embed_query("hello world")
+
+        self.assertEqual(vector, [0.7, 0.8, 0.9])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add BailianEmbedding that reuses the DashScope-compatible OpenAI client with Bailian defaults
- export the provider for consumers of core.embedding
- add unit coverage for Bailian embeddings

## Testing
```
conda run -n adk-embed bash -lc 'PYTHONPATH=src python -m pytest tests/test_bailian_embedding.py tests/test_openai_embedding.py'
```

<img width="1804" height="550" alt="image" src="https://github.com/user-attachments/assets/74801f8f-6502-4f94-9b17-43ee5e0eab34" />


Fixes #25