### PR TITLE
feat(python): add AWS(Bedrock) embedding provider

### DIFF
--- a/ali-agentic-adk-python/pyproject.toml
+++ b/ali-agentic-adk-python/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "aiohttp",
     "dashscope",
     "openai",
+    "boto3",
 
     # Alibaba Cloud SDKs
     "alibabacloud_ecd20200930",

--- a/ali-agentic-adk-python/requirements.txt
+++ b/ali-agentic-adk-python/requirements.txt
@@ -3,6 +3,7 @@ google-adk
 aiohttp
 dashscope
 openai
+boto3
 
 # Alibaba Cloud SDKs
 alibabacloud_ecd20200930

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/__init__.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/__init__.py
@@ -21,8 +21,10 @@
 
 from .basic_embedding import BasicEmbedding
 from .openai_embedding import OpenAIEmbedding
+from .aws_embedding import AWSEmbedding
 
 __all__ = [
     "BasicEmbedding",
     "OpenAIEmbedding",
+    "AWSEmbedding",
 ]

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/aws_embedding.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/embedding/aws_embedding.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Sequence
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from ..common.exceptions import EmbeddingProviderError
+from .basic_embedding import BasicEmbedding
+
+logger = logging.getLogger(__name__)
+
+
+class AWSEmbedding(BasicEmbedding):
+
+    """Embedding provider backed by Amazon Bedrock embedding models."""
+    def __init__(
+        self,
+        model: str,
+        *,
+        region_name: str | None = None,
+        endpoint_url: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        session_token: str | None = None,
+        profile_name: str | None = None,
+        client: Any | None = None,
+        client_kwargs: Dict[str, Any] | None = None,
+        body_options: Dict[str, Any] | None = None,
+        invoke_options: Dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(model=model)
+
+        if client is not None:
+            self._client = client
+        else:
+            session_kwargs: Dict[str, Any] = {}
+            if profile_name:
+                session_kwargs["profile_name"] = profile_name
+            if region_name:
+                session_kwargs["region_name"] = region_name
+            if access_key_id:
+                session_kwargs["aws_access_key_id"] = access_key_id
+            if secret_access_key:
+                session_kwargs["aws_secret_access_key"] = secret_access_key
+            if session_token:
+                session_kwargs["aws_session_token"] = session_token
+
+            session = boto3.session.Session(**session_kwargs)
+            client_kwargs = client_kwargs.copy() if client_kwargs else {}
+            if endpoint_url:
+                client_kwargs["endpoint_url"] = endpoint_url
+            self._client = session.client("bedrock-runtime", **client_kwargs)
+
+        self._body_options = body_options.copy() if body_options else {}
+        self._invoke_options: Dict[str, Any] = {
+            "accept": "application/json",
+            "contentType": "application/json",
+        }
+        if invoke_options:
+            self._invoke_options.update(invoke_options)
+
+    def embed_documents(self, texts: Sequence[str]) -> List[List[float]]:
+        normalized_inputs = self._normalize_inputs(texts)
+        if not normalized_inputs:
+            return []
+
+        embeddings: List[List[float]] = []
+        for text in normalized_inputs:
+            body_payload: Dict[str, Any] = {"inputText": text}
+            if self._body_options:
+                body_payload.update(self._body_options)
+
+            try:
+                response = self._client.invoke_model(
+                    modelId=self.model,
+                    body=json.dumps(body_payload),
+                    **self._invoke_options,
+                )
+            except (BotoCoreError, ClientError) as exc: 
+                message = "Failed to retrieve embeddings from AWS Bedrock provider"
+                logger.exception(message)
+                raise EmbeddingProviderError(message, original_exception=exc) from exc
+            except Exception as exc: 
+                message = "Unexpected error while invoking AWS Bedrock provider"
+                logger.exception(message)
+                raise EmbeddingProviderError(message, original_exception=exc) from exc
+
+            raw_body = response.get("body")
+            if raw_body is None:
+                raise EmbeddingProviderError("AWS Bedrock response did not include body content")
+
+            if hasattr(raw_body, "read"):
+                raw_body = raw_body.read()
+
+            if isinstance(raw_body, (bytes, bytearray)):
+                raw_body = raw_body.decode("utf-8")
+
+            try:
+                parsed = json.loads(raw_body)
+            except (TypeError, ValueError) as exc:
+                message = "Failed to parse AWS Bedrock embedding response body"
+                logger.exception(message)
+                raise EmbeddingProviderError(message, original_exception=exc) from exc
+
+            vector = self._extract_embedding_vector(parsed)
+            if vector is None:
+                raise EmbeddingProviderError("AWS Bedrock response did not contain embedding vectors")
+
+            embeddings.append(self._coerce_vector(vector))
+
+        return embeddings
+
+    @staticmethod
+    def _extract_embedding_vector(payload: Dict[str, Any]) -> Sequence[Any] | None:
+        direct_vector = payload.get("embedding") or payload.get("outputEmbedding")
+        if direct_vector:
+            return direct_vector
+
+        embeddings_by_type = payload.get("embeddingsByType")
+        if isinstance(embeddings_by_type, dict):
+            for candidate_key in ("float", "FLOAT", "default"):
+                candidate = embeddings_by_type.get(candidate_key)
+                if candidate:
+                    return candidate
+            for candidate in embeddings_by_type.values():
+                if candidate:
+                    return candidate
+
+        embeddings_field = payload.get("embeddings")
+        if isinstance(embeddings_field, list) and embeddings_field:
+            first_item = embeddings_field[0]
+            if isinstance(first_item, list) and first_item:
+                return first_item
+            if isinstance(first_item, dict):
+                nested = first_item.get("embedding") or first_item.get("vector")
+                if nested:
+                    return nested
+
+        return None
+
+    @staticmethod
+    def _coerce_vector(vector: Sequence[Any]) -> List[float]:
+        try:
+            return [float(component) for component in vector]
+        except (TypeError, ValueError) as exc:
+            raise EmbeddingProviderError(
+                "AWS Bedrock embedding vector contained non-numeric values",
+                original_exception=exc,
+            ) from exc
+
+
+__all__ = ["AWSEmbedding"]

--- a/ali-agentic-adk-python/tests/test_aws_embedding.py
+++ b/ali-agentic-adk-python/tests/test_aws_embedding.py
@@ -1,0 +1,142 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ali_agentic_adk_python.core.common.exceptions import EmbeddingProviderError
+from ali_agentic_adk_python.core.embedding.aws_embedding import AWSEmbedding
+
+
+class AWSEmbeddingTestCase(unittest.TestCase):
+    @patch("ali_agentic_adk_python.core.embedding.aws_embedding.boto3")
+    def test_embed_documents_returns_vectors(self, boto3_module):
+        session_mock = MagicMock()
+        client_mock = MagicMock()
+        boto3_module.session.Session.return_value = session_mock
+        session_mock.client.return_value = client_mock
+
+        first_stream = MagicMock()
+        first_stream.read.return_value = json.dumps({"embedding": [0.1, 0.2]}).encode()
+        second_stream = MagicMock()
+        second_stream.read.return_value = json.dumps({"embedding": [0.3, 0.4]}).encode()
+        client_mock.invoke_model.side_effect = [
+            {"body": first_stream},
+            {"body": second_stream},
+        ]
+
+        embedding = AWSEmbedding(
+            model="amazon.titan-embed-text-v1",
+            region_name="us-east-1",
+        )
+        vectors = embedding.embed_documents(["hello", "world"])
+
+        self.assertEqual(vectors, [[0.1, 0.2], [0.3, 0.4]])
+        self.assertEqual(client_mock.invoke_model.call_count, 2)
+        call_args = client_mock.invoke_model.call_args_list[0][1]
+        self.assertEqual(call_args["modelId"], "amazon.titan-embed-text-v1")
+        self.assertEqual(
+            json.loads(call_args["body"]),
+            {"inputText": "hello"},
+        )
+
+    @patch("ali_agentic_adk_python.core.embedding.aws_embedding.boto3")
+    def test_body_and_invoke_options_forwarded(self, boto3_module):
+        session_mock = MagicMock()
+        client_mock = MagicMock()
+        boto3_module.session.Session.return_value = session_mock
+        session_mock.client.return_value = client_mock
+
+        stream = MagicMock()
+        stream.read.return_value = json.dumps({"embedding": [0.5, 0.6]}).encode()
+        client_mock.invoke_model.return_value = {"body": stream}
+
+        embedding = AWSEmbedding(
+            model="cohere.embed-english-v3",
+            region_name="us-west-2",
+            body_options={"dimension": 1024},
+            invoke_options={"responseStream": False, "accept": "application/json"},
+        )
+        embedding.embed_documents(["text"])
+
+        client_mock.invoke_model.assert_called_once()
+        kwargs = client_mock.invoke_model.call_args.kwargs
+        self.assertEqual(kwargs["modelId"], "cohere.embed-english-v3")
+        self.assertEqual(json.loads(kwargs["body"]), {"inputText": "text", "dimension": 1024})
+        self.assertFalse(kwargs.get("responseStream", True))
+        self.assertEqual(kwargs["accept"], "application/json")
+
+    @patch("ali_agentic_adk_python.core.embedding.aws_embedding.boto3")
+    def test_missing_vectors_raise(self, boto3_module):
+        session_mock = MagicMock()
+        client_mock = MagicMock()
+        boto3_module.session.Session.return_value = session_mock
+        session_mock.client.return_value = client_mock
+
+        stream = MagicMock()
+        stream.read.return_value = json.dumps({"foo": "bar"}).encode()
+        client_mock.invoke_model.return_value = {"body": stream}
+
+        embedding = AWSEmbedding(model="amazon.titan-embed-text-v1")
+
+        with self.assertRaises(EmbeddingProviderError):
+            embedding.embed_documents(["text"])
+
+    @patch("ali_agentic_adk_python.core.embedding.aws_embedding.boto3")
+    def test_embeddings_by_type_used_when_embedding_missing(self, boto3_module):
+        session_mock = MagicMock()
+        client_mock = MagicMock()
+        boto3_module.session.Session.return_value = session_mock
+        session_mock.client.return_value = client_mock
+
+        stream = MagicMock()
+        stream.read.return_value = json.dumps({
+            "embeddingsByType": {"binary": [1, 0, 1, 0]},
+        }).encode()
+        client_mock.invoke_model.return_value = {"body": stream}
+
+        embedding = AWSEmbedding(
+            model="amazon.titan-embed-text-v2:0",
+            body_options={"embeddingTypes": ["binary"]},
+        )
+
+        result = embedding.embed_documents(["sample"])
+
+        self.assertEqual(result, [[1.0, 0.0, 1.0, 0.0]])
+
+    @patch("ali_agentic_adk_python.core.embedding.aws_embedding.boto3")
+    def test_embeddings_field_supported(self, boto3_module):
+        session_mock = MagicMock()
+        client_mock = MagicMock()
+        boto3_module.session.Session.return_value = session_mock
+        session_mock.client.return_value = client_mock
+
+        stream = MagicMock()
+        stream.read.return_value = json.dumps({
+            "embeddings": [[0.9, 0.8, 0.7]],
+        }).encode()
+        client_mock.invoke_model.return_value = {"body": stream}
+
+        embedding = AWSEmbedding(model="cohere.embed-english-v3")
+
+        result = embedding.embed_documents(["example"])
+
+        self.assertEqual(result, [[0.9, 0.8, 0.7]])
+
+    @patch("ali_agentic_adk_python.core.embedding.aws_embedding.boto3")
+    def test_embed_query_returns_single_vector(self, boto3_module):
+        session_mock = MagicMock()
+        client_mock = MagicMock()
+        boto3_module.session.Session.return_value = session_mock
+        session_mock.client.return_value = client_mock
+
+        stream = MagicMock()
+        stream.read.return_value = json.dumps({"embedding": [0.7, 0.8]}).encode()
+        client_mock.invoke_model.return_value = {"body": stream}
+
+        embedding = AWSEmbedding(model="amazon.titan-embed-text-v1")
+        vector = embedding.embed_query("hello")
+
+        self.assertEqual(vector, [0.7, 0.8])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- introduce `AWSEmbedding` with Bedrock-compatible client setup and flexible response parsing
- coerce Bedrock responses that surface `embedding`, `embeddingsByType`, or `embeddings` into float vectors
- extend AWS embedding unit coverage to validate the additional response formats

## Testing
```
cd ali-agentic-adk-python && PYTHONPATH=src python -m unittest tests.test_aws_embedding tests.test_openai_embedding
```
<img width="878" height="145" alt="image" src="https://github.com/user-attachments/assets/68939e1f-9fe0-4fcf-82d4-6dca0f723cae" />

Fixes #25