### PR TITLE
feat: add Cerebras LLM adapters for Python and Java (non-intrusive)

### DIFF
--- a/ali-agentic-adk-java/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/models/CerebrasLlm.java
+++ b/ali-agentic-adk-java/ali-agentic-adk-core/src/main/java/com/alibaba/agentic/core/models/CerebrasLlm.java
@@ -1,0 +1,156 @@
+package com.alibaba.agentic.core.models;
+
+import com.alibaba.agentic.core.engine.delegation.domain.LlmRequest;
+import com.alibaba.agentic.core.engine.delegation.domain.LlmResponse;
+import com.alibaba.agentic.core.executor.InvokeMode;
+import com.alibaba.agentic.core.executor.SystemContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.reactivex.rxjava3.core.Flowable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Minimal Cerebras Cloud LLM adapter.
+ * - Non-streaming chat completion is supported.
+ * - Streaming (SSE) is not implemented to avoid extra deps; will fall back to non-stream.
+ *
+ * Use by setting LlmRequest.model to "cerebras" and modelName to a concrete model (e.g., "llama3.1-8b").
+ */
+@Slf4j
+@Component
+public class CerebrasLlm implements BasicLlm {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String model() {
+        return "cerebras";
+    }
+
+    @Override
+    public Flowable<LlmResponse> invoke(LlmRequest llmRequest, SystemContext systemContext) {
+        // Fallback: even if SSE requested, use non-stream for now to avoid new deps
+        return Flowable.fromCallable(() -> callChatOnce(llmRequest));
+    }
+
+    private LlmResponse callChatOnce(LlmRequest req) throws Exception {
+        String apiKey = firstNonEmpty(
+                System.getProperty("ali.agentic.adk.flownode.cerebras.apiKey"),
+                System.getenv("CEREBRAS_API_KEY")
+        );
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IllegalStateException("CEREBRAS_API_KEY is required for CerebrasLlm");
+        }
+        String baseUrl = firstNonEmpty(
+                System.getProperty("CEREBRAS_BASE_URL"),
+                System.getenv("CEREBRAS_BASE_URL"),
+                "https://api.cerebras.ai"
+        );
+        String modelName = req.getModelName() != null ? req.getModelName() : req.getModel();
+        if (modelName == null || modelName.isEmpty()) {
+            modelName = "llama3.1-8b";
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", modelName);
+        body.put("messages", toMessages(req));
+        // optional knobs
+        if (req.getMaxTokens() != null) body.put("max_completion_tokens", req.getMaxTokens());
+        if (req.getTemperature() != null) body.put("temperature", req.getTemperature());
+        if (req.getTopP() != null) body.put("top_p", req.getTopP());
+        if (req.getStop() != null) body.put("stop", req.getStop());
+        if (req.getUser() != null) body.put("user", req.getUser());
+
+        String json = MAPPER.writeValueAsString(body);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(normalizeUrl(baseUrl) + "/v1/chat/completions"))
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(60))
+                .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8))
+                .build();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (resp.statusCode() / 100 != 2) {
+            log.warn("Cerebras call failed: {} - {}", resp.statusCode(), resp.body());
+            LlmResponse.ErrorInfo error = new LlmResponse.ErrorInfo();
+            error.setCode(String.valueOf(resp.statusCode()));
+            error.setType("cerebras_api_error");
+            error.setMessage(resp.body());
+            return new LlmResponse().setError(error);
+        }
+        return parseChatCompletion(resp.body());
+    }
+
+    private static List<Map<String, Object>> toMessages(LlmRequest llmRequest) {
+        if (llmRequest.getMessages() == null) return List.of();
+        return llmRequest.getMessages().stream().map(m -> {
+            Map<String, Object> mm = new LinkedHashMap<>();
+            mm.put("role", m.getRole() == null ? "user" : m.getRole());
+            mm.put("content", m.getContent());
+            return mm;
+        }).collect(Collectors.toList());
+    }
+
+    private LlmResponse parseChatCompletion(String body) throws Exception {
+        JsonNode root = MAPPER.readTree(body);
+        LlmResponse response = new LlmResponse();
+        if (root.hasNonNull("id")) response.setId(root.get("id").asText());
+
+        // usage
+        if (root.has("usage") && root.get("usage").isObject()) {
+            JsonNode u = root.get("usage");
+            LlmResponse.Usage usage = new LlmResponse.Usage();
+            if (u.hasNonNull("prompt_tokens")) usage.setPromptTokens(u.get("prompt_tokens").asInt());
+            if (u.hasNonNull("completion_tokens")) usage.setCompletionTokens(u.get("completion_tokens").asInt());
+            if (u.hasNonNull("total_tokens")) usage.setTotalTokens(u.get("total_tokens").asInt());
+            response.setUsage(usage);
+        }
+
+        // choices
+        if (root.has("choices") && root.get("choices").isArray() && root.get("choices").size() > 0) {
+            JsonNode c0 = root.get("choices").get(0);
+            LlmResponse.Choice c = new LlmResponse.Choice();
+            if (c0.hasNonNull("finish_reason")) c.setFinishReason(c0.get("finish_reason").asText());
+            if (c0.hasNonNull("index")) c.setIndex(c0.get("index").asInt());
+            JsonNode message = c0.get("message");
+            if (message != null && message.hasNonNull("content")) {
+                String content = message.get("content").asText();
+                c.setText(content);
+                LlmResponse.Message m = new LlmResponse.Message();
+                m.setRole(message.hasNonNull("role") ? message.get("role").asText() : "assistant");
+                m.setContent(content);
+                c.setMessage(m);
+            }
+            response.setChoices(List.of(c));
+        }
+        return response;
+    }
+
+    private static String normalizeUrl(String base) {
+        if (base.endsWith("/")) return base.substring(0, base.length() - 1);
+        return base;
+    }
+
+    @SafeVarargs
+    private static <T> T firstNonEmpty(T... vals) {
+        for (T v : vals) {
+            if (v instanceof String) {
+                if (v != null && !((String) v).isEmpty()) return v;
+            } else if (v != null) return v;
+        }
+        return null;
+    }
+}
+

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/model/cerebras_llm.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/model/cerebras_llm.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+from google.adk.models import LlmRequest, LlmResponse, BaseLlm
+
+from ali_agentic_adk_python.core.utils.cerebras_utils import CerebrasUtils
+from ali_agentic_adk_python.core.utils.dashscope_message_convert_utils import DashscopeMessageConverter
+
+
+class CerebrasLLM(BaseLlm):
+    """Cerebras Cloud adapter for Google ADK BaseLlm.
+
+    This wrapper prefers using the official cerebras_cloud_sdk if available. It
+    does not add the dependency to project requirements by default to avoid
+    conflicts. If the SDK is not installed, an ImportError will be raised when
+    invoking.
+    """
+
+    def __init__(self, api_key: str | None = None, *, base_url: str | None = None, model: str = "llama3.1-8b"):
+        super().__init__(model=model)
+        self._api_key = api_key
+        self._base_url = base_url
+        self._client = None
+
+    @classmethod
+    def from_env(cls, *, model: str = "llama3.1-8b") -> "CerebrasLLM":
+        import os
+        return cls(api_key=os.environ.get("CEREBRAS_API_KEY"), base_url=os.environ.get("CEREBRAS_BASE_URL"), model=model)
+
+    def _ensure_client(self):
+        if self._client is not None:
+            return
+        try:
+            from cerebras.cloud.sdk import Cerebras
+        except Exception as e:
+            raise ImportError(
+                "cerebras_cloud_sdk is required for CerebrasLLM. Install with `pip install cerebras_cloud_sdk`"
+            ) from e
+        self._client = Cerebras(api_key=self._api_key, base_url=self._base_url) if (self._api_key or self._base_url) else Cerebras()
+
+    async def generate_content_async(self, llm_request: LlmRequest, stream: bool = False) -> AsyncGenerator[LlmResponse, None]:
+        async for r in self._invoke(llm_request, stream):
+            yield r
+
+    async def _invoke(self, request: LlmRequest, stream: bool) -> AsyncGenerator[LlmResponse, None]:
+        self._ensure_client()
+        # map request to Cerebras chat params
+        messages = DashscopeMessageConverter.to_qwen_messages(request)
+        tools = DashscopeMessageConverter.to_qwen_tools(request)
+
+        if stream:
+            stream_obj = self._client.chat.completions.create(
+                messages=messages,
+                model=request.model,
+                tools=tools,
+                stream=True,
+            )
+            async for resp in CerebrasUtils.to_llm_response_stream(stream_obj):
+                yield resp
+        else:
+            result = self._client.chat.completions.create(
+                messages=messages,
+                model=request.model,
+                tools=tools,
+                stream=False,
+            )
+            yield CerebrasUtils.to_llm_response(result)
+
+    def get_api_key(self):
+        return self._api_key
+

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/utils/cerebras_utils.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/utils/cerebras_utils.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Any
+
+from google.adk.models import LlmResponse
+from google.genai import types
+from google.genai.types import FunctionCall
+
+
+class CerebrasUtils:
+    @staticmethod
+    def to_llm_response(result: Any) -> LlmResponse:
+        """Convert a Cerebras ChatCompletion (non-stream) to LlmResponse.
+
+        The `result` is expected to be an instance of `ChatCompletionResponse`
+        (from cerebras.cloud.sdk.types.chat.chat_completion), but we avoid direct
+        typing/imports here to keep this file import-light.
+        """
+        llm_response = LlmResponse()
+        if result is None:
+            return llm_response
+
+        # id, usage
+        if getattr(result, "id", None):
+            llm_response.id = getattr(result, "id")
+        usage = getattr(result, "usage", None)
+        if usage is not None:
+            prompt_tokens = getattr(usage, "prompt_tokens", None)
+            completion_tokens = getattr(usage, "completion_tokens", None)
+            total_tokens = getattr(usage, "total_tokens", None)
+            if any(v is not None for v in (prompt_tokens, completion_tokens, total_tokens)):
+                llm_response.usage_metadata = types.GenerateContentResponseUsageMetadata(
+                    prompt_token_count=prompt_tokens or 0,
+                    candidates_token_count=completion_tokens or 0,
+                    total_token_count=total_tokens or 0,
+                )
+
+        # choices[0]
+        choices = getattr(result, "choices", None) or []
+        if choices:
+            choice0 = choices[0]
+            message = getattr(choice0, "message", None)
+            finish_reason = getattr(choice0, "finish_reason", None)
+            # text
+            if message is not None and getattr(message, "content", None):
+                llm_response.content = types.Content(
+                    role=getattr(message, "role", "assistant"),
+                    parts=[types.Part(text=getattr(message, "content"))],
+                )
+            # tools
+            tool_calls = getattr(message, "tool_calls", None)
+            if tool_calls:
+                parts = []
+                for tc in tool_calls:
+                    fn = getattr(tc, "function", None)
+                    if fn is None:
+                        continue
+                    name = getattr(fn, "name", "")
+                    args_str = getattr(fn, "arguments", "{}")
+                    try:
+                        import json
+                        args_val = json.loads(args_str) if isinstance(args_str, str) else args_str
+                    except Exception:
+                        args_val = {}
+                    parts.append(types.Part(function_call=FunctionCall(name=name, args=args_val, id=getattr(tc, "id", None))))
+                if parts:
+                    llm_response.content = types.Content(role="assistant", parts=parts)
+
+            # partial or final
+            if finish_reason in ("stop", "tool_calls"):
+                llm_response.partial = False
+            else:
+                llm_response.partial = True
+
+        return llm_response
+
+    @staticmethod
+    async def to_llm_response_stream(stream: Any) -> AsyncGenerator[LlmResponse, None]:
+        """Convert a Cerebras streaming iterator to async generator of LlmResponse.
+
+        We expect `stream` to be an iterator over ChatChunkResponse; we yield text/tool
+        deltas as partial chunks and emit a final LlmResponse with usage if present.
+        """
+        import json
+
+        acc_text = ""
+        fn_calls = {}
+        usage_meta = None
+        final_emitted = False
+
+        for chunk in stream:
+            if chunk is None:
+                continue
+            choices = getattr(chunk, "choices", None) or []
+            if choices:
+                ch0 = choices[0]
+                delta = getattr(ch0, "delta", None)
+                finish = getattr(ch0, "finish_reason", None)
+
+                # text delta
+                if delta is not None and getattr(delta, "content", None):
+                    text_piece = getattr(delta, "content")
+                    acc_text += text_piece
+                    yield LlmResponse(
+                        content=types.Content(role="assistant", parts=[types.Part(text=text_piece)]),
+                        partial=True,
+                    )
+
+                # tool delta
+                tool_calls = getattr(delta, "tool_calls", None)
+                if tool_calls:
+                    for tc in tool_calls:
+                        idx = getattr(tc, "index", 0) or 0
+                        fn = getattr(tc, "function", None)
+                        if fn is None:
+                            continue
+                        name = getattr(fn, "name", None)
+                        args_piece = getattr(fn, "arguments", None)
+                        if idx not in fn_calls:
+                            fn_calls[idx] = {"name": "", "args": "", "id": getattr(tc, "id", None)}
+                        if name:
+                            fn_calls[idx]["name"] = name
+                        if args_piece:
+                            fn_calls[idx]["args"] += args_piece
+
+                # usage only in final chunk generally
+                usage = getattr(chunk, "usage", None)
+                if usage is not None:
+                    usage_meta = types.GenerateContentResponseUsageMetadata(
+                        prompt_token_count=getattr(usage, "prompt_tokens", 0) or 0,
+                        candidates_token_count=getattr(usage, "completion_tokens", 0) or 0,
+                        total_token_count=getattr(usage, "total_tokens", 0) or 0,
+                    )
+
+                # finalize when finish reason present
+                if finish in ("tool_calls", "stop"):
+                    if fn_calls:
+                        parts = []
+                        for i in sorted(fn_calls.keys()):
+                            call = fn_calls[i]
+                            args_val = {}
+                            try:
+                                args_val = json.loads(call["args"]) if call["args"] else {}
+                            except Exception:
+                                args_val = {}
+                            parts.append(types.Part(function_call=FunctionCall(name=call.get("name", ""), args=args_val, id=call.get("id"))))
+                        yield LlmResponse(content=types.Content(role="assistant", parts=parts), partial=False, usage_metadata=usage_meta)
+                        final_emitted = True
+                        fn_calls.clear()
+                        acc_text = ""
+                    elif acc_text:
+                        yield LlmResponse(content=types.Content(role="assistant", parts=[types.Part(text=acc_text)]), partial=False, usage_metadata=usage_meta)
+                        final_emitted = True
+                        acc_text = ""
+
+        if not final_emitted and (acc_text or usage_meta is not None):
+            yield LlmResponse(content=types.Content(role="assistant", parts=[types.Part(text=acc_text)]) if acc_text else None, partial=False, usage_metadata=usage_meta)
+


### PR DESCRIPTION
Cerebras is one of the fastest large model inference platforms/brands in the industry, focusing on high throughput and ultra-low latency inference. The task is to add a non-intrusive adapter (Python supports streaming, Java supports non-streaming first), without affecting existing logic by default. If there are any questions, feel free to contact me!