### PR TITLE
feat: Add ExcelDocLoader, PPTDocLoader, and YuqueDocLoader

### DIFF
--- a/ali-agentic-adk-python/requirements.txt
+++ b/ali-agentic-adk-python/requirements.txt
@@ -13,6 +13,8 @@ replicate
 PyPDF2
 PyYAML
 python-docx
+openpyxl>=3.1.0
+python-pptx>=0.6.21
 
 # Alibaba Cloud SDKs
 alibabacloud_ecd20200930

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/__init__.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/__init__.py
@@ -21,11 +21,14 @@
 
 from .docloader import (
     BaseLoader,
+    ExcelDocLoader,
     FeishuDocLoader,
     MarkdownDocLoader,
     PDFDocLoader,
+    PPTDocLoader,
     TextDocLoader,
     WordDocLoader,
+    YuqueDocLoader,
 )
 from .indexes import Document
 from .text_splitter import RecursiveCharacterTextSplitter, TextSplitter
@@ -33,11 +36,14 @@ from .text_splitter import RecursiveCharacterTextSplitter, TextSplitter
 __all__ = [
     "BaseLoader",
     "Document",
+    "ExcelDocLoader",
     "FeishuDocLoader",
     "MarkdownDocLoader",
     "PDFDocLoader",
+    "PPTDocLoader",
     "RecursiveCharacterTextSplitter",
     "TextDocLoader",
     "TextSplitter",
     "WordDocLoader",
+    "YuqueDocLoader",
 ]

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/__init__.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/__init__.py
@@ -19,17 +19,23 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from .base import BaseLoader
+from .excel_loader import ExcelDocLoader
 from .feishu_loader import FeishuDocLoader
 from .markdown_loader import MarkdownDocLoader
 from .pdf_loader import PDFDocLoader
+from .ppt_loader import PPTDocLoader
 from .text_loader import TextDocLoader
 from .word_loader import WordDocLoader
+from .yuque_loader import YuqueDocLoader
 
 __all__ = [
     "BaseLoader",
+    "ExcelDocLoader",
     "FeishuDocLoader",
     "MarkdownDocLoader",
     "PDFDocLoader",
+    "PPTDocLoader",
     "TextDocLoader",
     "WordDocLoader",
+    "YuqueDocLoader",
 ]

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/excel_loader.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/excel_loader.py
@@ -1,0 +1,326 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from io import BytesIO
+import logging
+from pathlib import Path
+from typing import Any, BinaryIO, Optional
+
+import openpyxl
+from openpyxl.worksheet.worksheet import Worksheet
+
+from ali_agentic_adk_python.core.docloader.base import BaseLoader
+from ali_agentic_adk_python.core.indexes import Document
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ExcelDocLoader(BaseLoader):
+    """Load Excel files (XLSX, XLS) and convert sheets into ``Document`` objects.
+    
+    This loader processes Excel workbooks and converts each sheet into a separate document.
+    The content can be formatted as:
+    - CSV-like text (default): Each row as comma-separated values
+    - Markdown tables: Formatted as markdown table syntax
+    - JSON: Each row as a JSON object
+    
+    Example:
+        >>> loader = ExcelDocLoader("data.xlsx", output_format="markdown")
+        >>> documents = loader.load()
+        >>> for doc in documents:
+        ...     print(f"Sheet: {doc.metadata['sheet_name']}")
+        ...     print(doc.page_content)
+    """
+
+    def __init__(
+        self, 
+        file_path: Optional[str] = None,
+        *,
+        output_format: str = "csv",
+        include_header: bool = True,
+        max_rows: Optional[int] = None,
+    ) -> None:
+        """Initialize the Excel document loader.
+        
+        Args:
+            file_path: Path to the Excel file
+            output_format: Output format ('csv', 'markdown', or 'json')
+            include_header: Whether to include the header row
+            max_rows: Maximum number of rows to process per sheet (None for all)
+        """
+        self.file_path = file_path
+        self.output_format = output_format.lower()
+        self.include_header = include_header
+        self.max_rows = max_rows
+        
+        if self.output_format not in ("csv", "markdown", "json"):
+            raise ValueError(f"Invalid output_format: {output_format}. Must be 'csv', 'markdown', or 'json'")
+
+    def load(self) -> list[Document]:
+        """Load the Excel file and convert to documents.
+        
+        Returns:
+            List of Document objects, one per sheet
+            
+        Raises:
+            ValueError: If file_path is not set
+            FileNotFoundError: If the file does not exist
+        """
+        if not self.file_path:
+            raise ValueError("ExcelDocLoader requires `file_path` or metadata-driven loading.")
+        return self._load_from_path(self.file_path)
+
+    def fetch_content(self, document_meta: dict[str, Any]) -> list[Document]:
+        """Load Excel file using metadata parameters.
+        
+        Args:
+            document_meta: Dictionary containing:
+                - file_path or filePath: Path to the file
+                - input_stream, stream, or bytes: File content
+                - metadata: Additional metadata to merge
+                
+        Returns:
+            List of Document objects
+        """
+        metadata_hint = document_meta.get("metadata")
+
+        file_path = document_meta.get("file_path") or document_meta.get("filePath")
+        if file_path:
+            documents = self._load_from_path(str(file_path))
+        elif stream := (
+            document_meta.get("input_stream")
+            or document_meta.get("stream")
+            or document_meta.get("binary_stream")
+        ):
+            documents = self._load_from_stream(stream)
+        elif raw_bytes := document_meta.get("bytes"):
+            documents = self._load_from_stream(BytesIO(raw_bytes))
+        else:
+            documents = super().fetch_content(document_meta)
+
+        if metadata_hint:
+            for doc in documents:
+                doc.metadata.update(metadata_hint)
+        return documents
+
+    def _load_from_path(self, file_path: str) -> list[Document]:
+        """Load Excel file from a file path.
+        
+        Args:
+            file_path: Path to the Excel file
+            
+        Returns:
+            List of Document objects
+            
+        Raises:
+            FileNotFoundError: If the file does not exist
+        """
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        
+        workbook = openpyxl.load_workbook(path, read_only=True, data_only=True)
+        return self._extract_documents(workbook, str(path))
+
+    def _load_from_stream(self, stream: BinaryIO | BytesIO) -> list[Document]:
+        """Load Excel file from a byte stream.
+        
+        Args:
+            stream: Binary stream containing Excel file data
+            
+        Returns:
+            List of Document objects
+        """
+        workbook = openpyxl.load_workbook(stream, read_only=True, data_only=True)
+        return self._extract_documents(workbook, None)
+
+    def _extract_documents(
+        self, 
+        workbook: openpyxl.Workbook, 
+        source: Optional[str]
+    ) -> list[Document]:
+        """Extract documents from an Excel workbook.
+        
+        Args:
+            workbook: Opened Excel workbook
+            source: Source file path (None if from stream)
+            
+        Returns:
+            List of Document objects
+        """
+        documents: list[Document] = []
+        
+        for sheet_name in workbook.sheetnames:
+            try:
+                sheet = workbook[sheet_name]
+                content = self._format_sheet(sheet)
+                
+                metadata = {
+                    "source": source or "stream",
+                    "sheet_name": sheet_name,
+                    "format": "excel",
+                    "output_format": self.output_format,
+                    "max_row": sheet.max_row,
+                    "max_column": sheet.max_column,
+                }
+                
+                document = Document(page_content=content, metadata=metadata)
+                documents.append(document)
+                
+            except Exception as exc:
+                LOGGER.warning(f"Failed to process sheet '{sheet_name}': {exc}")
+                continue
+        
+        return documents
+
+    def _format_sheet(self, sheet: Worksheet) -> str:
+        """Format a worksheet according to the output format.
+        
+        Args:
+            sheet: Excel worksheet to format
+            
+        Returns:
+            Formatted content as string
+        """
+        # Collect all rows
+        rows = []
+        row_count = 0
+        
+        for row in sheet.iter_rows(values_only=True):
+            if self.max_rows and row_count >= self.max_rows:
+                break
+                
+            # Skip empty rows
+            if all(cell is None or str(cell).strip() == "" for cell in row):
+                continue
+                
+            # Convert cells to strings
+            row_data = [str(cell) if cell is not None else "" for cell in row]
+            rows.append(row_data)
+            row_count += 1
+        
+        if not rows:
+            return ""
+        
+        # Format based on output format
+        if self.output_format == "csv":
+            return self._format_as_csv(rows)
+        elif self.output_format == "markdown":
+            return self._format_as_markdown(rows)
+        elif self.output_format == "json":
+            return self._format_as_json(rows)
+        else:
+            return self._format_as_csv(rows)
+
+    def _format_as_csv(self, rows: list[list[str]]) -> str:
+        """Format rows as CSV text.
+        
+        Args:
+            rows: List of rows, each row is a list of cell values
+            
+        Returns:
+            CSV-formatted string
+        """
+        lines = []
+        for row in rows:
+            # Escape commas and quotes in cells
+            escaped_row = []
+            for cell in row:
+                if "," in cell or '"' in cell:
+                    escaped_cell = f'"{cell.replace(chr(34), chr(34) + chr(34))}"'
+                    escaped_row.append(escaped_cell)
+                else:
+                    escaped_row.append(cell)
+            lines.append(",".join(escaped_row))
+        return "\n".join(lines)
+
+    def _format_as_markdown(self, rows: list[list[str]]) -> str:
+        """Format rows as a Markdown table.
+        
+        Args:
+            rows: List of rows, each row is a list of cell values
+            
+        Returns:
+            Markdown table string
+        """
+        if not rows:
+            return ""
+        
+        lines = []
+        
+        # Header row
+        if self.include_header and len(rows) > 0:
+            header = rows[0]
+            lines.append("| " + " | ".join(header) + " |")
+            lines.append("|" + "|".join(["---" for _ in header]) + "|")
+            data_rows = rows[1:]
+        else:
+            # Generate column headers if not including first row as header
+            num_cols = len(rows[0]) if rows else 0
+            header = [f"Column {i+1}" for i in range(num_cols)]
+            lines.append("| " + " | ".join(header) + " |")
+            lines.append("|" + "|".join(["---" for _ in header]) + "|")
+            data_rows = rows
+        
+        # Data rows
+        for row in data_rows:
+            # Escape pipe characters in cells
+            escaped_row = [cell.replace("|", chr(92) + "|") for cell in row]
+            lines.append("| " + " | ".join(escaped_row) + " |")
+        
+        return "\n".join(lines)
+
+    def _format_as_json(self, rows: list[list[str]]) -> str:
+        """Format rows as JSON array of objects.
+        
+        Args:
+            rows: List of rows, each row is a list of cell values
+            
+        Returns:
+            JSON string
+        """
+        import json
+        
+        if not rows:
+            return "[]"
+        
+        # Use first row as keys if include_header is True
+        if self.include_header and len(rows) > 1:
+            keys = rows[0]
+            data_rows = rows[1:]
+        else:
+            # Generate keys
+            num_cols = len(rows[0]) if rows else 0
+            keys = [f"column_{i+1}" for i in range(num_cols)]
+            data_rows = rows
+        
+        # Build array of objects
+        result = []
+        for row in data_rows:
+            # Pad row if it's shorter than keys
+            padded_row = row + [""] * (len(keys) - len(row))
+            row_dict = {keys[i]: padded_row[i] for i in range(len(keys))}
+            result.append(row_dict)
+        
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
+

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/ppt_loader.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/ppt_loader.py
@@ -1,0 +1,327 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from io import BytesIO
+import logging
+from pathlib import Path
+from typing import Any, BinaryIO, Optional
+
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+from ali_agentic_adk_python.core.docloader.base import BaseLoader
+from ali_agentic_adk_python.core.indexes import Document
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PPTDocLoader(BaseLoader):
+    """Load PowerPoint files (PPTX, PPT) and convert slides into ``Document`` objects.
+    
+    This loader processes PowerPoint presentations and converts each slide into a separate document.
+    It extracts:
+    - Text from all text boxes and shapes
+    - Titles and content placeholders
+    - Tables (formatted as markdown or CSV)
+    - Notes (speaker notes)
+    
+    Example:
+        >>> loader = PPTDocLoader("presentation.pptx", include_notes=True)
+        >>> documents = loader.load()
+        >>> for doc in documents:
+        ...     print(f"Slide {doc.metadata['slide_number']}")
+        ...     print(doc.page_content)
+    """
+
+    def __init__(
+        self, 
+        file_path: Optional[str] = None,
+        *,
+        include_notes: bool = False,
+        table_format: str = "markdown",
+        slide_separator: str = "\n\n---\n\n",
+    ) -> None:
+        """Initialize the PowerPoint document loader.
+        
+        Args:
+            file_path: Path to the PowerPoint file
+            include_notes: Whether to include speaker notes
+            table_format: Format for tables ('markdown' or 'csv')
+            slide_separator: Separator between content sections in a slide
+        """
+        self.file_path = file_path
+        self.include_notes = include_notes
+        self.table_format = table_format.lower()
+        self.slide_separator = slide_separator
+        
+        if self.table_format not in ("markdown", "csv"):
+            raise ValueError(f"Invalid table_format: {table_format}. Must be 'markdown' or 'csv'")
+
+    def load(self) -> list[Document]:
+        """Load the PowerPoint file and convert to documents.
+        
+        Returns:
+            List of Document objects, one per slide
+            
+        Raises:
+            ValueError: If file_path is not set
+            FileNotFoundError: If the file does not exist
+        """
+        if not self.file_path:
+            raise ValueError("PPTDocLoader requires `file_path` or metadata-driven loading.")
+        return self._load_from_path(self.file_path)
+
+    def fetch_content(self, document_meta: dict[str, Any]) -> list[Document]:
+        """Load PowerPoint file using metadata parameters.
+        
+        Args:
+            document_meta: Dictionary containing:
+                - file_path or filePath: Path to the file
+                - input_stream, stream, or bytes: File content
+                - metadata: Additional metadata to merge
+                
+        Returns:
+            List of Document objects
+        """
+        metadata_hint = document_meta.get("metadata")
+
+        file_path = document_meta.get("file_path") or document_meta.get("filePath")
+        if file_path:
+            documents = self._load_from_path(str(file_path))
+        elif stream := (
+            document_meta.get("input_stream")
+            or document_meta.get("stream")
+            or document_meta.get("binary_stream")
+        ):
+            documents = self._load_from_stream(stream)
+        elif raw_bytes := document_meta.get("bytes"):
+            documents = self._load_from_stream(BytesIO(raw_bytes))
+        else:
+            documents = super().fetch_content(document_meta)
+
+        if metadata_hint:
+            for doc in documents:
+                doc.metadata.update(metadata_hint)
+        return documents
+
+    def _load_from_path(self, file_path: str) -> list[Document]:
+        """Load PowerPoint file from a file path.
+        
+        Args:
+            file_path: Path to the PowerPoint file
+            
+        Returns:
+            List of Document objects
+            
+        Raises:
+            FileNotFoundError: If the file does not exist
+        """
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        
+        presentation = Presentation(str(path))
+        return self._extract_documents(presentation, str(path))
+
+    def _load_from_stream(self, stream: BinaryIO | BytesIO) -> list[Document]:
+        """Load PowerPoint file from a byte stream.
+        
+        Args:
+            stream: Binary stream containing PowerPoint file data
+            
+        Returns:
+            List of Document objects
+        """
+        presentation = Presentation(stream)
+        return self._extract_documents(presentation, None)
+
+    def _extract_documents(
+        self, 
+        presentation: Presentation, 
+        source: Optional[str]
+    ) -> list[Document]:
+        """Extract documents from a PowerPoint presentation.
+        
+        Args:
+            presentation: Opened PowerPoint presentation
+            source: Source file path (None if from stream)
+            
+        Returns:
+            List of Document objects
+        """
+        documents: list[Document] = []
+        
+        for slide_idx, slide in enumerate(presentation.slides, start=1):
+            try:
+                content_parts = []
+                
+                # Extract text from all shapes
+                for shape in slide.shapes:
+                    shape_text = self._extract_shape_text(shape)
+                    if shape_text:
+                        content_parts.append(shape_text)
+                
+                # Extract speaker notes if requested
+                notes_text = ""
+                if self.include_notes and slide.has_notes_slide:
+                    notes_slide = slide.notes_slide
+                    notes_text = notes_slide.notes_text_frame.text if notes_slide.notes_text_frame else ""
+                    if notes_text.strip():
+                        content_parts.append(f"**Notes:**\n{notes_text}")
+                
+                # Combine all content
+                content = self.slide_separator.join(content_parts)
+                
+                metadata = {
+                    "source": source or "stream",
+                    "slide_number": slide_idx,
+                    "format": "powerpoint",
+                    "has_notes": bool(notes_text),
+                    "shape_count": len(slide.shapes),
+                }
+                
+                document = Document(page_content=content, metadata=metadata)
+                documents.append(document)
+                
+            except Exception as exc:
+                LOGGER.warning(f"Failed to process slide {slide_idx}: {exc}")
+                continue
+        
+        return documents
+
+    def _extract_shape_text(self, shape) -> str:
+        """Extract text from a PowerPoint shape.
+        
+        Args:
+            shape: PowerPoint shape object
+            
+        Returns:
+            Extracted text content
+        """
+        text_parts = []
+        
+        # Check if shape has text frame
+        if hasattr(shape, "text") and shape.text:
+            text_parts.append(shape.text)
+        
+        # Handle tables specially
+        if shape.shape_type == MSO_SHAPE_TYPE.TABLE:
+            table_text = self._extract_table_text(shape.table)
+            if table_text:
+                text_parts.append(table_text)
+        
+        # Handle grouped shapes
+        elif shape.shape_type == MSO_SHAPE_TYPE.GROUP:
+            for grouped_shape in shape.shapes:
+                grouped_text = self._extract_shape_text(grouped_shape)
+                if grouped_text:
+                    text_parts.append(grouped_text)
+        
+        # Handle text boxes and placeholders
+        elif hasattr(shape, "text_frame") and shape.text_frame:
+            frame_text = []
+            for paragraph in shape.text_frame.paragraphs:
+                para_text = paragraph.text.strip()
+                if para_text:
+                    frame_text.append(para_text)
+            if frame_text:
+                text_parts.append("\n".join(frame_text))
+        
+        return "\n".join(text_parts)
+
+    def _extract_table_text(self, table) -> str:
+        """Extract and format text from a PowerPoint table.
+        
+        Args:
+            table: PowerPoint table object
+            
+        Returns:
+            Formatted table text
+        """
+        rows = []
+        
+        for row in table.rows:
+            row_cells = []
+            for cell in row.cells:
+                cell_text = cell.text.strip()
+                row_cells.append(cell_text)
+            rows.append(row_cells)
+        
+        if not rows:
+            return ""
+        
+        if self.table_format == "markdown":
+            return self._format_table_as_markdown(rows)
+        else:
+            return self._format_table_as_csv(rows)
+
+    def _format_table_as_markdown(self, rows: list[list[str]]) -> str:
+        """Format table rows as Markdown.
+        
+        Args:
+            rows: List of rows, each row is a list of cell values
+            
+        Returns:
+            Markdown table string
+        """
+        if not rows:
+            return ""
+        
+        lines = []
+        
+        # First row as header
+        if rows:
+            header = rows[0]
+            lines.append("| " + " | ".join(header) + " |")
+            lines.append("|" + "|".join(["---" for _ in header]) + "|")
+        
+        # Data rows
+        for row in rows[1:]:
+            # Escape pipe characters
+            escaped_row = [cell.replace("|", chr(92) + "|") for cell in row]
+            lines.append("| " + " | ".join(escaped_row) + " |")
+        
+        return "\n".join(lines)
+
+    def _format_table_as_csv(self, rows: list[list[str]]) -> str:
+        """Format table rows as CSV.
+        
+        Args:
+            rows: List of rows, each row is a list of cell values
+            
+        Returns:
+            CSV string
+        """
+        lines = []
+        for row in rows:
+            # Escape commas and quotes
+            escaped_row = []
+            for cell in row:
+                if "," in cell or '"' in cell:
+                    escaped_cell = f'"{cell.replace(chr(34), chr(34) + chr(34))}"'
+                    escaped_row.append(escaped_cell)
+                else:
+                    escaped_row.append(cell)
+            lines.append(",".join(escaped_row))
+        return "\n".join(lines)
+
+

--- a/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/yuque_loader.py
+++ b/ali-agentic-adk-python/src/ali_agentic_adk_python/core/docloader/yuque_loader.py
@@ -1,0 +1,271 @@
+# Copyright (C) 2025 AIDC-AI
+# This project incorporates components from the Open Source Software below.
+# The original copyright notices and the licenses under which we received such components are set forth below for informational purposes.
+#
+# Open Source Software Licensed under the MIT License:
+# --------------------------------------------------------------------
+# 1. vscode-extension-updater-gitlab 3.0.1 https://www.npmjs.com/package/vscode-extension-updater-gitlab
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2015 David Owens II
+# Copyright (c) Microsoft Corporation.
+# Terms of the MIT:
+# --------------------------------------------------------------------
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+from ali_agentic_adk_python.core.docloader.base import BaseLoader
+from ali_agentic_adk_python.core.indexes import Document
+
+LOGGER = logging.getLogger(__name__)
+
+
+_DEFAULT_DOMAIN = "https://www.yuque.com/api/v2"
+
+
+class YuqueAPIError(RuntimeError):
+    """Signal that the Yuque API returned an error response."""
+
+
+@dataclass
+class _AuthToken:
+    token: str
+
+
+class YuqueDocLoader(BaseLoader):
+    """Load documents from Yuque (语雀) knowledge base via the API.
+    
+    Yuque is a popular knowledge management platform in China. This loader supports:
+    - Loading individual documents by slug
+    - Loading all documents from a repository
+    - Loading documents from a specific namespace
+    
+    API Documentation: https://www.yuque.com/yuque/developer/api
+    
+    Example:
+        >>> loader = YuqueDocLoader(token="your_personal_token")
+        >>> loader.namespace = "user/repo"
+        >>> documents = loader.load()
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        timeout: float = 60.0,
+        domain: str = _DEFAULT_DOMAIN,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        """Initialize the Yuque document loader.
+        
+        Args:
+            token: Personal access token from Yuque
+            timeout: Request timeout in seconds
+            domain: API domain (default: https://www.yuque.com/api/v2)
+            session: Optional requests session for custom configuration
+        """
+        self.token = token
+        self.timeout = timeout
+        self.domain = domain.rstrip("/")
+        self.doc_slug: Optional[str] = None  # Single document slug
+        self.namespace: Optional[str] = None  # Repository namespace (user/repo)
+        self.page_size: int = 100  # Max items per page
+        self._session = session or requests.Session()
+
+    def load(self) -> list[Document]:
+        """Load documents based on configured parameters.
+        
+        Returns:
+            List of Document objects with content and metadata
+        """
+        if self.doc_slug and self.namespace:
+            return self._load_document(self.namespace, self.doc_slug)
+        if self.namespace:
+            return self._load_repository_documents(self.namespace)
+        LOGGER.warning("YuqueDocLoader called without doc_slug or namespace; returning empty list")
+        return []
+
+    def fetch_content(self, document_meta: dict[str, Any]) -> list[Document]:
+        """Load documents using metadata parameters.
+        
+        Args:
+            document_meta: Dictionary containing:
+                - doc_slug: Document slug (optional)
+                - namespace: Repository namespace (required)
+                - metadata: Additional metadata to merge (optional)
+                
+        Returns:
+            List of Document objects
+        """
+        metadata_hint = document_meta.get("metadata")
+        original_docs: list[Document]
+        
+        namespace = document_meta.get("namespace")
+        doc_slug = document_meta.get("doc_slug")
+        
+        if doc_slug and namespace:
+            original_docs = self._load_document(str(namespace), str(doc_slug))
+        elif namespace:
+            original_docs = self._load_repository_documents(str(namespace))
+        else:
+            original_docs = super().fetch_content(document_meta)
+
+        if metadata_hint:
+            for doc in original_docs:
+                doc.metadata.update(metadata_hint)
+        return original_docs
+
+    # --------------------------------------------------------------------- #
+    # API helpers
+    # --------------------------------------------------------------------- #
+
+    def _headers(self) -> Dict[str, str]:
+        """Get request headers with authentication token.
+        
+        Returns:
+            Dictionary of HTTP headers
+        """
+        return {
+            "X-Auth-Token": self.token,
+            "User-Agent": "Agentic-ADK-YuqueLoader/1.0",
+            "Content-Type": "application/json",
+        }
+
+    def _request_json(self, method: str, url: str, **kwargs: Any) -> Dict[str, Any]:
+        """Make an authenticated API request.
+        
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            url: Full API URL
+            **kwargs: Additional requests arguments
+            
+        Returns:
+            Parsed JSON response
+            
+        Raises:
+            YuqueAPIError: If the API returns an error
+        """
+        kwargs.setdefault("timeout", self.timeout)
+        response = self._session.request(method, url, headers=self._headers(), **kwargs)
+        response.raise_for_status()
+        data = response.json()
+        
+        # Yuque API returns errors in the response body
+        if not data.get("data") and data.get("message"):
+            raise YuqueAPIError(f"Yuque API error: {data.get('message')}")
+            
+        return data
+
+    # --------------------------------------------------------------------- #
+    # Document loading paths
+    # --------------------------------------------------------------------- #
+
+    def _load_document(self, namespace: str, doc_slug: str) -> list[Document]:
+        """Load a single document by namespace and slug.
+        
+        Args:
+            namespace: Repository namespace (e.g., "user/repo")
+            doc_slug: Document slug identifier
+            
+        Returns:
+            List containing one Document object
+            
+        Raises:
+            YuqueAPIError: If the document cannot be loaded
+        """
+        url = f"{self.domain}/repos/{namespace}/docs/{doc_slug}"
+        payload = self._request_json("GET", url)
+        
+        doc_data = payload.get("data", {})
+        
+        # Yuque returns content in different formats
+        # body_draft: draft content
+        # body: published content  
+        # body_html: HTML format
+        content = doc_data.get("body") or doc_data.get("body_draft", "")
+        
+        metadata = {
+            "doc_slug": doc_slug,
+            "namespace": namespace,
+            "doc_id": doc_data.get("id"),
+            "title": doc_data.get("title"),
+            "source": f"https://www.yuque.com/{namespace}/{doc_slug}",
+            "format": doc_data.get("format", "markdown"),  # Usually 'markdown' or 'lake'
+            "created_at": doc_data.get("created_at"),
+            "updated_at": doc_data.get("updated_at"),
+            "word_count": doc_data.get("word_count"),
+            "public": doc_data.get("public"),
+        }
+        
+        # Remove None values
+        metadata = {k: v for k, v in metadata.items() if v is not None}
+        
+        document = Document(page_content=content, metadata=metadata)
+        return [document]
+
+    def _load_repository_documents(self, namespace: str) -> list[Document]:
+        """Load all documents from a Yuque repository.
+        
+        Args:
+            namespace: Repository namespace (e.g., "user/repo")
+            
+        Returns:
+            List of Document objects
+        """
+        documents: list[Document] = []
+        offset = 0
+
+        while True:
+            # List documents in the repository
+            url = f"{self.domain}/repos/{namespace}/docs"
+            params = {
+                "offset": offset,
+                "limit": self.page_size,
+            }
+            
+            payload = self._request_json("GET", url, params=params)
+            doc_list: Iterable[Dict[str, Any]] = payload.get("data") or []
+            
+            if not doc_list:
+                break
+                
+            for item in doc_list:
+                doc_slug = item.get("slug")
+                if not doc_slug:
+                    continue
+                    
+                try:
+                    # Load full document content
+                    loaded = self._load_document(namespace, doc_slug)
+                    
+                    # Add repository-level metadata
+                    for doc in loaded:
+                        doc.metadata.setdefault("description", item.get("description"))
+                        
+                    documents.extend(loaded)
+                except YuqueAPIError as exc:
+                    LOGGER.warning("Skipping Yuque document %s: %s", doc_slug, exc)
+                except Exception as exc:
+                    LOGGER.error("Unexpected error loading document %s: %s", doc_slug, exc)
+            
+            # Check if there are more pages
+            if len(doc_list) < self.page_size:
+                break
+                
+            offset += self.page_size
+
+        return documents
+
+

--- a/ali-agentic-adk-python/tests/test_docloader.py
+++ b/ali-agentic-adk-python/tests/test_docloader.py
@@ -9,15 +9,21 @@ from typing import Any, Dict, Iterable, Tuple
 import pytest
 from PyPDF2 import PdfWriter
 from docx import Document as WordDocument
+import openpyxl
+from pptx import Presentation
+from pptx.util import Inches
 
 from ali_agentic_adk_python.core import (
     Document,
+    ExcelDocLoader,
     FeishuDocLoader,
     MarkdownDocLoader,
     PDFDocLoader,
+    PPTDocLoader,
     RecursiveCharacterTextSplitter,
     TextDocLoader,
     WordDocLoader,
+    YuqueDocLoader,
 )
 
 
@@ -1201,3 +1207,392 @@ def test_metadata_null_values():
     assert doc.metadata["key2"] == ""
     assert doc.metadata["key3"] == 0
     assert doc.metadata["key4"] is False
+
+
+# ============================================================================
+# ExcelDocLoader Tests
+# ============================================================================
+
+def test_excel_doc_loader_reads_file(tmp_path):
+    """Test basic Excel file loading with CSV format"""
+    excel_path = tmp_path / "test.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Sheet1"
+    sheet.append(["Name", "Age", "City"])
+    sheet.append(["Alice", 30, "New York"])
+    sheet.append(["Bob", 25, "London"])
+    workbook.save(excel_path)
+    
+    loader = ExcelDocLoader(str(excel_path), output_format="csv")
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    doc = documents[0]
+    assert "Name" in doc.page_content
+    assert "Alice" in doc.page_content
+    assert doc.metadata["sheet_name"] == "Sheet1"
+    assert doc.metadata["format"] == "excel"
+
+
+def test_excel_doc_loader_markdown_format(tmp_path):
+    """Test Excel loading with markdown table format"""
+    excel_path = tmp_path / "test_md.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.append(["Product", "Price"])
+    sheet.append(["Apple", 1.50])
+    sheet.append(["Orange", 2.00])
+    workbook.save(excel_path)
+    
+    loader = ExcelDocLoader(str(excel_path), output_format="markdown")
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    assert "| Product | Price |" in documents[0].page_content
+    assert "|---|---|" in documents[0].page_content
+
+
+def test_excel_doc_loader_json_format(tmp_path):
+    """Test Excel loading with JSON format"""
+    excel_path = tmp_path / "test_json.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.append(["id", "name"])
+    sheet.append([1, "item1"])
+    sheet.append([2, "item2"])
+    workbook.save(excel_path)
+    
+    loader = ExcelDocLoader(str(excel_path), output_format="json")
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    data = json.loads(documents[0].page_content)
+    assert len(data) == 2
+    assert data[0]["id"] == "1"
+
+
+def test_excel_doc_loader_multiple_sheets(tmp_path):
+    """Test Excel file with multiple sheets"""
+    excel_path = tmp_path / "multi.xlsx"
+    workbook = openpyxl.Workbook()
+    workbook.remove(workbook.active)
+    
+    sheet1 = workbook.create_sheet("Sales")
+    sheet1.append(["Product", "Sales"])
+    sheet1.append(["A", 100])
+    
+    sheet2 = workbook.create_sheet("Inventory")
+    sheet2.append(["Item", "Stock"])
+    sheet2.append(["X", 50])
+    
+    workbook.save(excel_path)
+    
+    loader = ExcelDocLoader(str(excel_path))
+    documents = loader.load()
+    
+    assert len(documents) == 2
+    sheet_names = {doc.metadata["sheet_name"] for doc in documents}
+    assert sheet_names == {"Sales", "Inventory"}
+
+
+def test_excel_doc_loader_raises_when_path_missing():
+    """Test Excel loader raises error when no file path provided"""
+    loader = ExcelDocLoader()
+    with pytest.raises(ValueError):
+        loader.load()
+
+
+def test_excel_doc_loader_fetches_from_metadata_bytes(tmp_path):
+    """Test Excel loader with byte stream input"""
+    excel_path = tmp_path / "bytes.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.append(["A", "B"])
+    sheet.append([1, 2])
+    workbook.save(excel_path)
+    
+    with open(excel_path, "rb") as f:
+        excel_bytes = f.read()
+    
+    loader = ExcelDocLoader()
+    documents = loader.fetch_content({"bytes": excel_bytes})
+    
+    assert len(documents) == 1
+    assert documents[0].metadata["source"] == "stream"
+
+
+def test_excel_doc_loader_max_rows(tmp_path):
+    """Test max_rows parameter limits row processing"""
+    excel_path = tmp_path / "many_rows.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.append(["Col1", "Col2"])
+    for i in range(1, 101):
+        sheet.append([f"R{i}", f"V{i}"])
+    workbook.save(excel_path)
+    
+    loader = ExcelDocLoader(str(excel_path), max_rows=10)
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    line_count = len(documents[0].page_content.split("\n"))
+    assert line_count <= 11
+
+
+# ============================================================================
+# PPTDocLoader Tests
+# ============================================================================
+
+def test_ppt_doc_loader_reads_file(tmp_path):
+    """Test basic PowerPoint file loading"""
+    ppt_path = tmp_path / "test.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    
+    textbox = slide.shapes.add_textbox(
+        Inches(1), Inches(1), Inches(8), Inches(1)
+    )
+    textbox.text = "Slide Title"
+    
+    textbox2 = slide.shapes.add_textbox(
+        Inches(1), Inches(2), Inches(8), Inches(4)
+    )
+    textbox2.text = "Slide Content"
+    
+    presentation.save(str(ppt_path))
+    
+    loader = PPTDocLoader(str(ppt_path))
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    assert documents[0].metadata["slide_number"] == 1
+    assert "Slide Title" in documents[0].page_content
+    assert "Slide Content" in documents[0].page_content
+
+
+def test_ppt_doc_loader_multiple_slides(tmp_path):
+    """Test PowerPoint with multiple slides"""
+    ppt_path = tmp_path / "multi.pptx"
+    presentation = Presentation()
+    
+    for i in range(1, 4):
+        slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+        textbox = slide.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(8), Inches(1)
+        )
+        textbox.text = f"Slide {i}"
+    
+    presentation.save(str(ppt_path))
+    
+    loader = PPTDocLoader(str(ppt_path))
+    documents = loader.load()
+    
+    assert len(documents) == 3
+    assert documents[0].metadata["slide_number"] == 1
+    assert documents[2].metadata["slide_number"] == 3
+
+
+def test_ppt_doc_loader_with_notes(tmp_path):
+    """Test PowerPoint with speaker notes"""
+    ppt_path = tmp_path / "notes.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    
+    textbox = slide.shapes.add_textbox(
+        Inches(1), Inches(1), Inches(8), Inches(1)
+    )
+    textbox.text = "Main Content"
+    
+    notes_slide = slide.notes_slide
+    notes_slide.notes_text_frame.text = "Speaker notes here"
+    
+    presentation.save(str(ppt_path))
+    
+    loader = PPTDocLoader(str(ppt_path), include_notes=True)
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    assert "Main Content" in documents[0].page_content
+    assert "Speaker notes here" in documents[0].page_content
+    assert documents[0].metadata["has_notes"] is True
+
+
+def test_ppt_doc_loader_without_notes(tmp_path):
+    """Test PowerPoint without including speaker notes"""
+    ppt_path = tmp_path / "no_notes.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    
+    textbox = slide.shapes.add_textbox(
+        Inches(1), Inches(1), Inches(8), Inches(1)
+    )
+    textbox.text = "Content"
+    
+    notes_slide = slide.notes_slide
+    notes_slide.notes_text_frame.text = "Hidden notes"
+    
+    presentation.save(str(ppt_path))
+    
+    loader = PPTDocLoader(str(ppt_path), include_notes=False)
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    assert "Content" in documents[0].page_content
+    assert "Hidden notes" not in documents[0].page_content
+
+
+def test_ppt_doc_loader_raises_when_path_missing():
+    """Test PPT loader raises error when no file path provided"""
+    loader = PPTDocLoader()
+    with pytest.raises(ValueError):
+        loader.load()
+
+
+def test_ppt_doc_loader_fetches_from_metadata_bytes(tmp_path):
+    """Test PPT loader with byte stream input"""
+    ppt_path = tmp_path / "bytes.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(
+        Inches(1), Inches(1), Inches(8), Inches(1)
+    )
+    textbox.text = "From bytes"
+    presentation.save(str(ppt_path))
+    
+    with open(ppt_path, "rb") as f:
+        ppt_bytes = f.read()
+    
+    loader = PPTDocLoader()
+    documents = loader.fetch_content({"bytes": ppt_bytes})
+    
+    assert len(documents) == 1
+    assert documents[0].metadata["source"] == "stream"
+    assert "From bytes" in documents[0].page_content
+
+
+def test_ppt_doc_loader_empty_presentation(tmp_path):
+    """Test handling of empty PowerPoint presentation"""
+    ppt_path = tmp_path / "empty.pptx"
+    presentation = Presentation()
+    presentation.save(str(ppt_path))
+    
+    loader = PPTDocLoader(str(ppt_path))
+    documents = loader.load()
+    
+    assert len(documents) == 0
+
+
+# ============================================================================
+# YuqueDocLoader Tests
+# ============================================================================
+
+def test_yuque_doc_loader_single_document():
+    """Test loading a single Yuque document"""
+    domain = "https://www.yuque.com/api/v2"
+    responses = {
+        ("GET", f"{domain}/repos/user/repo/docs/test-doc"): {
+            "data": {
+                "id": 123,
+                "slug": "test-doc",
+                "title": "Test Document",
+                "body": "# Hello Yuque\n\nContent here.",
+                "format": "markdown",
+                "created_at": "2025-01-01T00:00:00Z",
+                "updated_at": "2025-01-02T00:00:00Z",
+                "word_count": 100,
+                "public": 1,
+            }
+        },
+    }
+    session = _StubSession(responses)
+    
+    loader = YuqueDocLoader(token="test_token", session=session)
+    loader.namespace = "user/repo"
+    loader.doc_slug = "test-doc"
+    
+    documents = loader.load()
+    
+    assert len(documents) == 1
+    doc = documents[0]
+    assert "Hello Yuque" in doc.page_content
+    assert doc.metadata["doc_slug"] == "test-doc"
+    assert doc.metadata["title"] == "Test Document"
+    assert doc.metadata["namespace"] == "user/repo"
+
+
+def test_yuque_doc_loader_repository_documents():
+    """Test loading all documents from a repository"""
+    domain = "https://www.yuque.com/api/v2"
+    responses = {
+        ("GET", f"{domain}/repos/user/repo/docs"): {
+            "data": [
+                {"slug": "doc1", "title": "Document 1"},
+                {"slug": "doc2", "title": "Document 2"},
+            ]
+        },
+        ("GET", f"{domain}/repos/user/repo/docs/doc1"): {
+            "data": {
+                "id": 1,
+                "slug": "doc1",
+                "title": "Document 1",
+                "body": "Content of doc1",
+                "format": "markdown",
+            }
+        },
+        ("GET", f"{domain}/repos/user/repo/docs/doc2"): {
+            "data": {
+                "id": 2,
+                "slug": "doc2",
+                "title": "Document 2",
+                "body": "Content of doc2",
+                "format": "markdown",
+            }
+        },
+    }
+    session = _StubSession(responses)
+    
+    loader = YuqueDocLoader(token="test_token", session=session)
+    loader.namespace = "user/repo"
+    
+    documents = loader.load()
+    
+    assert len(documents) == 2
+    assert documents[0].metadata["doc_slug"] == "doc1"
+    assert documents[1].metadata["doc_slug"] == "doc2"
+
+
+def test_yuque_doc_loader_fetches_from_metadata():
+    """Test Yuque loader with metadata-driven loading"""
+    domain = "https://www.yuque.com/api/v2"
+    responses = {
+        ("GET", f"{domain}/repos/user/repo/docs/meta-doc"): {
+            "data": {
+                "id": 999,
+                "slug": "meta-doc",
+                "title": "Meta Document",
+                "body": "Metadata test",
+                "format": "markdown",
+            }
+        },
+    }
+    session = _StubSession(responses)
+    
+    loader = YuqueDocLoader(token="test_token", session=session)
+    documents = loader.fetch_content({
+        "namespace": "user/repo",
+        "doc_slug": "meta-doc",
+        "metadata": {"category": "yuque", "custom": "value"}
+    })
+    
+    assert len(documents) == 1
+    assert documents[0].metadata["category"] == "yuque"
+    assert documents[0].metadata["custom"] == "value"
+    assert documents[0].metadata["doc_slug"] == "meta-doc"
+
+
+def test_yuque_doc_loader_empty_when_no_target():
+    """Test Yuque loader returns empty list when no target specified"""
+    loader = YuqueDocLoader(token="test_token")
+    documents = loader.load()
+    assert documents == []


### PR DESCRIPTION
  ## Describe what this PR does / why we need it

This PR adds three new document loaders to expand the framework's document processing capabilities. The ExcelDocLoader enables processing of spreadsheet data with flexible output formats, PPTDocLoader extracts structured content from presentations, and YuqueDocLoader integrates with the Yuque knowledge base platform for cloud document retrieval. These loaders follow the same design patterns as existing loaders and provide a consistent interface for document loading.

## Does this pull request fix one issue?

- [ ] Yes
- [x] No

## Describe how you did it

- Implemented ExcelDocLoader using openpyxl library to parse Excel files and support CSV, Markdown, and JSON output formats
- Implemented PPTDocLoader using python-pptx library to extract text from slides, shapes, tables, and speaker notes
- Implemented YuqueDocLoader with Yuque API v2 integration for loading documents from knowledge base repositories
- Extended the document loader exports in core/__init__.py and docloader/__init__.py
- Added 18 comprehensive unit tests covering basic functionality, error handling, and edge cases
- Updated requirements.txt with openpyxl>=3.1.0 and python-pptx>=0.6.21 dependencies

## Describe how to verify it

```bash
cd ali-agentic-adk-python
pytest tests/test_docloader.py::test_excel_doc_loader_reads_file -v
pytest tests/test_docloader.py::test_ppt_doc_loader_reads_file -v
pytest tests/test_docloader.py::test_yuque_doc_loader_single_document -v
```

## Special notes for reviews

All new loaders follow the BaseLoader interface pattern and maintain consistency with existing loaders (TextDocLoader, WordDocLoader, PDFDocLoader). The implementation is fully backward compatible with no breaking changes.